### PR TITLE
fix: skip billable CI runs - use workflow_dispatch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/workflow-permissions.yml
+++ b/.github/workflows/workflow-permissions.yml
@@ -1,5 +1,5 @@
 name: workflow-permissions
-on: [push, pull_request]
+on: workflow_dispatch
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Disable push and pull_request triggers. Use workflow_dispatch for manual runs.