### PR TITLE
chore: ignore cliff.toml artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests/
 worklogs/
 .archive/
 docs/AGENT_MASTER_AUDIT_PROMPT.md
+cliff.toml


### PR DESCRIPTION
Adds cliff.toml to .gitignore.