### PR TITLE
chore: ignore libs/ and platforms/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ worklogs/
 .archive/
 docs/AGENT_MASTER_AUDIT_PROMPT.md
 cliff.toml
+libs/
+platforms/


### PR DESCRIPTION
Adds libs/ and platforms/ to .gitignore.