### PR TITLE
chore: clean up phenotype-infrakit workspace structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ worklogs/
 .archive/
 docs/AGENT_MASTER_AUDIT_PROMPT.md
 cliff.toml
+libs/
+platforms/


### PR DESCRIPTION
Clean up the phenotype-infrakit workspace structure.

## Changes
- Remove duplicated crate directories
- Keep only proper nested crate structure  
- Update governance files to reference phenotype-infrakit

This is a reorganization PR for the phenotype-infrakit Rust monorepo.