### PR TITLE
chore: add git worktree health check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Cargo.lock
 worktrees/
 .worktrees/
 .archive/
-<<<<<<< HEAD
 docs/plans/
 docs/reports/
 evidence_ledger.jsonl
@@ -16,5 +15,3 @@ worklogs/
 docs/AGENT_MASTER_AUDIT_PROMPT.md
 libs/
 platforms/
-=======
->>>>>>> 0789c8632 (chore: ignore .archive build artifacts)


### PR DESCRIPTION
Adds scripts/git-worktree-health.sh to audit worktree state across all repos.