### PR TITLE
chore(deps): update tokio from 1.0 to 1.50

### DIFF
--- a/crates/phenotype-contracts/Cargo.toml
+++ b/crates/phenotype-contracts/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["architecture"]
 thiserror = "2.0"
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["sync", "time"] }
+tokio = { version = "1.50", features = ["sync", "time"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.50", features = ["full"] }


### PR DESCRIPTION
## Summary
- Update tokio dependency from 1.0 to 1.50.0 in phenotype-contracts
- Addresses critical version drift across Phenotype repos
- Maintains all existing features (sync, time)

## Verification
- Tokio version aligned with latest stable (1.50.0)
- Dependency specifications for both dev and runtime updated
- Maintains compatibility with async-trait and other tokio-dependent crates

## Test Plan
- [x] Dependency version updated
- [x] Manifest files validated
- [x] No breaking changes to API surface