### PR TITLE
chore(ci): CycloneDX SBOM pilot for phenotype-error-core

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,46 @@
+# CycloneDX SBOM pilot — single workspace member (supply-chain artifact).
+# Stacked delivery: land this workflow first; docs follow in a dependent PR.
+name: SBOM (CycloneDX pilot)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cyclonedx-phenotype-error-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-cyclonedx@0.5.9
+
+      - name: Generate CycloneDX JSON (pilot crate)
+        run: |
+          cargo cyclonedx \
+            --manifest-path crates/phenotype-error-core/Cargo.toml \
+            -f json \
+            --spec-version 1.5 \
+            --override-filename sbom-phenotype-error-core
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom-phenotype-error-core
+          path: crates/phenotype-error-core/sbom-phenotype-error-core.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
Adds a dedicated GitHub Actions workflow that generates a CycloneDX JSON SBOM (spec 1.5) for `crates/phenotype-error-core` using `cargo-cyclonedx` and uploads it as a workflow artifact.

## Stack
This is **PR 1 of 3** in a stacked delivery:
- **PR 1 (this)**: `sbom.yml` workflow
- **PR 2**: `docs/worklogs/DEPENDENCIES.md` — supply-chain row + pilot section (base: this branch)
- **PR 3**: session delivery note (base: PR 2 branch)

Merge **PR 1 first**, then retarget or rebase PR 2 onto `main` as needed.

Made with [Cursor](https://cursor.com)