### PR TITLE
docs(worklogs): CycloneDX SBOM pilot in DEPENDENCIES

### DIFF
--- a/docs/worklogs/DEPENDENCIES.md
+++ b/docs/worklogs/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Dependencies Worklogs
 
-**Category:** DEPENDENCIES | **Updated:** 2026-03-29
+**Category:** DEPENDENCIES | **Updated:** 2026-03-30 (SBOM pilot doc)
 
 ---
 
@@ -1710,7 +1710,7 @@ Create a unified dependency version policy:
 
 | Tool | Action |
 |------|--------|
-| `cargo-cyclonedx` | ADOPT for SBOM artifacts |
+| `cargo-cyclonedx` | **PILOT:** `.github/workflows/sbom.yml` → artifact `cyclonedx-sbom-phenotype-error-core` (crate `phenotype-error-core`, JSON spec 1.5) |
 | `syft` | WRAP in release pipeline |
 | OSV-Scanner | ADOPT for batch triage |
 | `cargo audit` + `cargo deny advisories` | Run both weekly |
@@ -1743,4 +1743,31 @@ Create a unified dependency version policy:
 
 ---
 
-_Last updated: 2026-03-29_
+## 2026-03-30 - CycloneDX SBOM pilot (CI)
+
+**Project:** phenotype-infrakit | **Status:** implemented | **Priority:** P1
+
+### What shipped
+
+| Item | Detail |
+|------|--------|
+| Workflow | `.github/workflows/sbom.yml` |
+| Triggers | `push` to `main`, `pull_request`, `workflow_dispatch` |
+| Tool | `cargo-cyclonedx@0.5.9` via `taiki-e/install-action` |
+| Pilot crate | `crates/phenotype-error-core` (minimal dependency surface) |
+| Output | `crates/phenotype-error-core/sbom-phenotype-error-core.json` |
+| Artifact name | `cyclonedx-sbom-phenotype-error-core` |
+
+### Stacked delivery
+
+1. **PR A** — workflow only (`chore/sbom-cyclonedx-pilot` → `main`).
+2. **PR B** — this doc update (`chore/docs-tooling-sbom-stack` → `chore/sbom-cyclonedx-pilot`). Merge **A** first, then retarget **B** to `main` or merge **B** after **A** lands.
+
+### Next expansions
+
+- [ ] Add additional workspace members or a matrix once pilot is stable.
+- [ ] Attach SBOM to GitHub Releases for tagged builds (release workflow).
+
+---
+
+_Last updated: 2026-03-30_


### PR DESCRIPTION
## Summary
Documents the CycloneDX SBOM pilot: supply-chain tooling row for `cargo-cyclonedx`, workflow table, stacked merge order, and follow-ups in `docs/worklogs/DEPENDENCIES.md`.

## Stack
- **PR 1**: https://github.com/KooshaPari/phenotype-infrakit/pull/99 — `sbom.yml`
- **PR 2 (this)**: docs on top of PR 1
- **PR 3**: session overview — base this PR’s branch after PR 1 merges (or use stacked base `chore/docs-tooling-sbom-stack`)

Merge order: PR 99 → then this PR (rebase onto `main` if GitHub shows conflicts after 99 merges).

Made with [Cursor](https://cursor.com)