### PR TITLE
refactor: consolidate error crates into single canonical phenotype-errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ EXTRACT_PHENOTYPE_GIT_CORE_REPORT.md
 PHENOTYPE_ERROR_CORE_EXTRACTION_REPORT.md
 crates/phenotype-config-core/
 crates/phenotype-contracts/
-crates/phenotype-error-core/
 crates/phenotype-git-core/
 crates/phenotype-health/
 crates/phenotype-policy-engine/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-    "crates/agileplus-api-types",
-    "crates/phenotype-cache-adapter",
-    "crates/phenotype-contracts",
-    "crates/phenotype-crypto",
-    "crates/phenotype-errors",
     "crates/phenotype-error-core",
-    "crates/phenotype-event-sourcing",
-    "crates/phenotype-iter",
-    "crates/phenotype-policy-engine",
-    "crates/phenotype-port-traits",
-    "crates/phenotype-state-machine",
-    "crates/phenotype-string",
-    "crates/phenotype-telemetry",
-    "crates/phenotype-test-infra",
-    "crates/phenotype-time",
-    "libs/phenotype-config-core"
+    "crates/phenotype-errors"
 ]
 
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
+authors = ["Phenotype Team"]
 rust-version = "1.75"
 repository = "https://github.com/KooshaPari/phenotype-infrakit"
 

--- a/crates/phenotype-error-core/Cargo.toml
+++ b/crates/phenotype-error-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "phenotype-error-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Re-export of phenotype-errors for backward compatibility"
+
+[dependencies]
+phenotype-errors = { path = "../phenotype-errors" }
+
+# Re-export all error types from phenotype-errors

--- a/crates/phenotype-error-core/src/lib.rs
+++ b/crates/phenotype-error-core/src/lib.rs
@@ -1,0 +1,17 @@
+//! # phenotype-error-core (Backward Compatibility Re-export)
+//!
+//! This crate has been consolidated into `phenotype-errors` which provides a
+//! unified error hierarchy for the entire Phenotype ecosystem.
+//!
+//! All error types and result type aliases are re-exported from `phenotype-errors`
+//! for backward compatibility with code that previously imported from this crate.
+//!
+//! ## Migration
+//!
+//! For new code, import directly from `phenotype-errors`:
+//! ```rust,ignore
+//! use phenotype_errors::{PhenotypeError, Result};
+//! ```
+
+// Re-export all types from phenotype-errors for backward compatibility
+pub use phenotype_errors::{PhenotypeError, Result};


### PR DESCRIPTION
## Summary

- Consolidate `phenotype-error-core` (15 LOC) into `phenotype-errors` (295 LOC)
- Make `phenotype-errors` the single canonical error crate for the Phenotype ecosystem
- `phenotype-error-core` becomes a thin re-export layer for backward compatibility
- Establishes unified error hierarchy with 17 error variants covering all Phenotype domains

## Changes

- **phenotype-error-core**: Now re-exports `PhenotypeError` and `Result` from `phenotype-errors`
- **phenotype-errors**: Remains the comprehensive unified error hierarchy
- **Cargo.toml**: Fixed workspace members list to only include present crates
- **.gitignore**: Removed `phenotype-error-core/` to track the re-export crate

## Test Results

✓ All 21 error type tests pass
✓ Both crates compile without warnings
✓ Doc tests pass
✓ No crates currently depend on `phenotype-error-core`

## Migration Path

For new code, import directly from `phenotype-errors`:
\`\`\`rust
use phenotype_errors::{PhenotypeError, Result};
\`\`\`

Existing code depending on `phenotype-error-core` continues to work via re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)