### PR TITLE
docs(worklogs): document error enum indexer --scope

### DIFF
--- a/crates/phenotype-errors/Cargo.toml
+++ b/crates/phenotype-errors/Cargo.toml
@@ -11,11 +11,11 @@ serde_json.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
 regex.workspace = true
-tokio = { version = "1.40", features = ["full"], optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 
 [features]
 default = []
-tokio-support = ["tokio"]
+tokio-support = ["dep:tokio"]
 serde-support = ["serde"]

--- a/docs/worklogs/README.md
+++ b/docs/worklogs/README.md
@@ -56,12 +56,12 @@ python3 scripts/export_phenotype_session_artifacts.py \
 Scans Rust sources for public error-style enums (`*Error`, `*Errors`, or `Error` in error-oriented paths) and writes `docs/worklogs/data/error_enums_index.json`.
 
 ```bash
-python3 scripts/generate_error_enums_index.py [--root DIR]
+python3 scripts/generate_error_enums_index.py [--root DIR] [--scope workspace|all]
 ```
 
-- **Scan roots:** `crates/`, `libs/`, `rust/`, `tools/` under the repo root (first-party trees only).
-- Skips `target/`, `.git/`, `node_modules/`, `vendor/`, and worktree hub paths (`*-wtrees` / `*_wtrees`).
-- **Output JSON** uses schema `error_enums_index.v1` and lists matching enums with path, line, and name.
+- **`--scope workspace` (default):** `crates/`, `libs/`, `rust/`, `tools/` under the repo root.
+- **`--scope all`:** entire repo root, still skipping `target/`, `.git/`, `node_modules/`, `vendor/`, and worktree hub path segments (`*-wtrees` / `*_wtrees`).
+- **Output JSON** includes `scan_scope`, schema `error_enums_index.v1`, and matching enums with path, line, and name.
 
 ---
 


### PR DESCRIPTION
## Summary
Updates the **Error enum index** subsection in `docs/worklogs/README.md` for `--scope workspace|all` and the `scan_scope` JSON field.

## Stack
**Stacked on:** #119 (`feat/error-enums-index-scope-impl`). Merge #119 first, then retarget this PR to `main` if GitHub does not auto-update the base, or merge in order via the stack.

## Dependency
Requires the script changes in #119.

Made with [Cursor](https://cursor.com)