### PR TITLE
fix(workspace): trim members; fix event-sourcing JsonEnvelope + EventStore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,24 @@ members = [
     "crates/agileplus-api-types",
     "crates/phenotype-cache-adapter",
     "crates/phenotype-contracts",
-    "crates/phenotype-crypto",
     "crates/phenotype-errors",
-    "crates/phenotype-error-core",
     "crates/phenotype-event-sourcing",
-    "crates/phenotype-iter",
     "crates/phenotype-policy-engine",
-    "crates/phenotype-port-traits",
     "crates/phenotype-state-machine",
-    "crates/phenotype-string",
     "crates/phenotype-telemetry",
     "crates/phenotype-test-infra",
+    "libs/phenotype-config-core",
+]
+
+# Crates not yet present or not wired into the workspace build.
+exclude = [
+    "crates/phenotype-crypto",
+    "crates/phenotype-error-core",
+    "crates/phenotype-iter",
+    "crates/phenotype-port-traits",
+    "crates/phenotype-string",
     "crates/phenotype-time",
-    "libs/phenotype-config-core"
+    "libs/phenotype-error-core.ARCHIVED",
 ]
 
 [workspace.package]
@@ -25,6 +30,7 @@ edition = "2021"
 license = "MIT"
 rust-version = "1.75"
 repository = "https://github.com/KooshaPari/phenotype-infrakit"
+authors = ["Phenotype Team"]
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/phenotype-event-sourcing/src/lib.rs
+++ b/crates/phenotype-event-sourcing/src/lib.rs
@@ -6,10 +6,11 @@ pub mod error;
 pub mod event;
 pub mod hash;
 pub mod memory;
+pub mod snapshot;
 pub mod store;
 
-pub use error::{EventSourcingError, Result};
+pub use error::{EventSourcingError, EventStoreError, HashError, Result};
 pub use event::EventEnvelope;
 pub use hash::{compute_event_hash, verify_event_hash};
 pub use memory::InMemoryEventStore;
-pub use store::EventStore;
+pub use store::{EventStore, JsonEnvelope};

--- a/crates/phenotype-event-sourcing/src/memory.rs
+++ b/crates/phenotype-event-sourcing/src/memory.rs
@@ -1,14 +1,12 @@
-//! In-memory event store for tests and development.
+//! In-memory [`EventStore`](crate::store::EventStore) with SHA-256 hash chain.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::RwLock;
 
-use crate::error::{EventSourcingError, EventStoreError, Result};
-use crate::event::EventEnvelope;
+use crate::error::{EventStoreError, Result};
 use crate::hash;
-use crate::store::EventStore;
+use crate::store::{EventStore, JsonEnvelope};
 
 /// Nested map: `entity_type` → `entity_id` → append-only event list.
 pub struct InMemoryEventStore {
@@ -34,17 +32,22 @@ impl InMemoryEventStore {
     }
 
     pub fn clear(&self) {
-        self.events.write().unwrap().clear();
+        if let Ok(mut g) = self.events.write() {
+            g.clear();
+        }
     }
 
     pub fn event_count(&self) -> usize {
         self.events
             .read()
-            .unwrap()
-            .values()
-            .flat_map(|m| m.values())
-            .map(|v| v.len())
-            .sum()
+            .map(|store| {
+                store
+                    .values()
+                    .flat_map(|m| m.values())
+                    .map(|v| v.len())
+                    .sum()
+            })
+            .unwrap_or(0)
     }
 }
 
@@ -55,9 +58,9 @@ impl Default for InMemoryEventStore {
 }
 
 impl EventStore for InMemoryEventStore {
-    fn append<T: Serialize + for<'de> Deserialize<'de>>(
+    fn append(
         &self,
-        event: &EventEnvelope<T>,
+        event: &JsonEnvelope,
         entity_type: &str,
         entity_id: &str,
     ) -> Result<i64> {
@@ -82,7 +85,7 @@ impl EventStore for InMemoryEventStore {
             events.last().unwrap().hash.clone()
         };
 
-        let payload_json = serde_json::to_value(&event.payload)?;
+        let payload_json = event.payload.clone();
 
         let hash = hash::compute_hash(
             &event.id,
@@ -106,11 +109,7 @@ impl EventStore for InMemoryEventStore {
         Ok(sequence)
     }
 
-    fn get_events<T: Serialize + for<'de> Deserialize<'de>>(
-        &self,
-        entity_type: &str,
-        entity_id: &str,
-    ) -> Result<Vec<EventEnvelope<T>>> {
+    fn get_events(&self, entity_type: &str, entity_id: &str) -> Result<Vec<JsonEnvelope>> {
         let store = self
             .events
             .read()
@@ -121,90 +120,45 @@ impl EventStore for InMemoryEventStore {
             .and_then(|m| m.get(entity_id))
             .ok_or_else(|| EventStoreError::NotFound(format!("{entity_type}/{entity_id}")))?;
 
-        events
+        Ok(events
             .iter()
-            .map(|se| {
-                let payload: T = serde_json::from_value(se.payload_json.clone())?;
-                Ok(EventEnvelope {
-                    id: se.id,
-                    timestamp: se.timestamp,
-                    payload,
-                    actor: se.actor.clone(),
-                    prev_hash: se.prev_hash.clone(),
-                    hash: se.hash.clone(),
-                    sequence: se.sequence,
-                })
+            .map(|se| JsonEnvelope {
+                id: se.id,
+                timestamp: se.timestamp,
+                payload: se.payload_json.clone(),
+                actor: se.actor.clone(),
+                prev_hash: se.prev_hash.clone(),
+                hash: se.hash.clone(),
+                sequence: se.sequence,
             })
-            .collect::<Result<Vec<_>, EventSourcingError>>()
+            .collect())
     }
 
-    fn get_events_since<T: Serialize + for<'de> Deserialize<'de>>(
+    fn get_events_since(
         &self,
         entity_type: &str,
         entity_id: &str,
         sequence: i64,
-    ) -> Result<Vec<EventEnvelope<T>>> {
-        let store = self
-            .events
-            .read()
-            .map_err(|_| EventStoreError::StorageError("lock poisoned".into()))?;
-
-        let events = store
-            .get(entity_type)
-            .and_then(|m| m.get(entity_id))
-            .ok_or_else(|| EventStoreError::NotFound(format!("{entity_type}/{entity_id}")))?;
-
-        events
-            .iter()
-            .filter(|se| se.sequence > sequence)
-            .map(|se| {
-                let payload: T = serde_json::from_value(se.payload_json.clone())?;
-                Ok(EventEnvelope {
-                    id: se.id,
-                    timestamp: se.timestamp,
-                    payload,
-                    actor: se.actor.clone(),
-                    prev_hash: se.prev_hash.clone(),
-                    hash: se.hash.clone(),
-                    sequence: se.sequence,
-                })
-            })
-            .collect::<Result<Vec<_>, EventSourcingError>>()
+    ) -> Result<Vec<JsonEnvelope>> {
+        Ok(self
+            .get_events(entity_type, entity_id)?
+            .into_iter()
+            .filter(|e| e.sequence > sequence)
+            .collect())
     }
 
-    fn get_events_by_range<T: Serialize + for<'de> Deserialize<'de>>(
+    fn get_events_by_range(
         &self,
         entity_type: &str,
         entity_id: &str,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
-    ) -> Result<Vec<EventEnvelope<T>>> {
-        let store = self
-            .events
-            .read()
-            .map_err(|_| EventStoreError::StorageError("lock poisoned".into()))?;
-
-        let events = store
-            .get(entity_type)
-            .and_then(|m| m.get(entity_id))
-            .ok_or_else(|| EventStoreError::NotFound(format!("{entity_type}/{entity_id}")))?;
-
-        events
-            .iter()
-            .filter(|se| se.timestamp >= from && se.timestamp <= to)
-            .map(|se| {
-                let payload: T = serde_json::from_value(se.payload_json.clone())?;
-                Ok(EventEnvelope {
-                    id: se.id,
-                    timestamp: se.timestamp,
-                    payload,
-                    actor: se.actor.clone(),
-                    prev_hash: se.prev_hash.clone(),
-                    hash: se.hash.clone(),
-                    sequence: se.sequence,
-                })
-            })
-            .collect::<Result<Vec<_>, EventSourcingError>>()
+    ) -> Result<Vec<JsonEnvelope>> {
+        Ok(self
+            .get_events(entity_type, entity_id)?
+            .into_iter()
+            .filter(|e| e.timestamp >= from && e.timestamp <= to)
+            .collect())
     }
 
     fn get_latest_sequence(&self, entity_type: &str, entity_id: &str) -> Result<i64> {
@@ -244,49 +198,33 @@ impl EventStore for InMemoryEventStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-    struct TestPayload {
-        value: i32,
-        name: String,
-    }
+    use serde_json::json;
 
     #[test]
     fn append_and_retrieve() {
         let store = InMemoryEventStore::new();
-        let payload = TestPayload {
-            value: 42,
-            name: "test".to_string(),
-        };
-        let event = EventEnvelope::new(payload.clone(), "user1");
+        let event = JsonEnvelope::new(
+            json!({
+                "value": 42,
+                "name": "test"
+            }),
+            "user1",
+        );
         let entity_id = "entity-1";
 
         let seq = store.append(&event, "TestEvent", entity_id).unwrap();
         assert_eq!(seq, 1);
 
-        let retrieved = store.get_events::<TestPayload>("TestEvent", entity_id).unwrap();
+        let retrieved = store.get_events("TestEvent", entity_id).unwrap();
         assert_eq!(retrieved.len(), 1);
-        assert_eq!(retrieved[0].payload.value, 42);
+        assert_eq!(retrieved[0].payload["value"], 42);
     }
 
     #[test]
     fn sequence_increments() {
         let store = InMemoryEventStore::new();
-        let e1 = EventEnvelope::new(
-            TestPayload {
-                value: 1,
-                name: "a".to_string(),
-            },
-            "user1",
-        );
-        let e2 = EventEnvelope::new(
-            TestPayload {
-                value: 2,
-                name: "b".to_string(),
-            },
-            "user1",
-        );
+        let e1 = JsonEnvelope::new(json!({"value": 1, "name": "a"}), "user1");
+        let e2 = JsonEnvelope::new(json!({"value": 2, "name": "b"}), "user1");
 
         let s1 = store.append(&e1, "Event", "entity-1").unwrap();
         let s2 = store.append(&e2, "Event", "entity-1").unwrap();

--- a/crates/phenotype-event-sourcing/src/store.rs
+++ b/crates/phenotype-event-sourcing/src/store.rs
@@ -5,6 +5,9 @@ use chrono::{DateTime, Utc};
 use crate::error::Result;
 use crate::event::EventEnvelope;
 
+/// JSON-backed envelope for stores that persist [`serde_json::Value`] payloads.
+pub type JsonEnvelope = EventEnvelope<serde_json::Value>;
+
 /// Generic event store for append-only event storage with hash chain support.
 ///
 /// Implementations of this trait are responsible for:
@@ -16,7 +19,7 @@ pub trait EventStore: Send + Sync {
     /// Append a new event; returns the assigned sequence number.
     fn append(
         &self,
-        event: &EventEnvelope,
+        event: &JsonEnvelope,
         entity_type: &str,
         entity_id: &str,
     ) -> Result<i64>;
@@ -26,7 +29,7 @@ pub trait EventStore: Send + Sync {
         &self,
         entity_type: &str,
         entity_id: &str,
-    ) -> Result<Vec<EventEnvelope>>;
+    ) -> Result<Vec<JsonEnvelope>>;
 
     /// Get events from a specific sequence onward (exclusive).
     fn get_events_since(
@@ -34,7 +37,7 @@ pub trait EventStore: Send + Sync {
         entity_type: &str,
         entity_id: &str,
         sequence: i64,
-    ) -> Result<Vec<EventEnvelope>>;
+    ) -> Result<Vec<JsonEnvelope>>;
 
     /// Get events within a time range (inclusive).
     fn get_events_by_range(
@@ -43,7 +46,7 @@ pub trait EventStore: Send + Sync {
         entity_id: &str,
         from: DateTime<Utc>,
         to: DateTime<Utc>,
-    ) -> Result<Vec<EventEnvelope>>;
+    ) -> Result<Vec<JsonEnvelope>>;
 
     /// Get the latest event sequence number for an entity (0 if none exist).
     fn get_latest_sequence(&self, entity_type: &str, entity_id: &str) -> Result<i64>;


### PR DESCRIPTION
## Summary
First layer of a three-PR stack: restore a loadable workspace and fix `phenotype-event-sourcing` so `cargo check --workspace` succeeds.

## Changes
- Trim `[workspace].members` to on-disk crates; add `exclude` for missing paths; set `workspace.package.authors`.
- Add `JsonEnvelope` alias, align `EventStore` and `InMemoryEventStore`, re-export snapshot + error types.

## Stack
- **This PR (1/3)** ← base: `main`
- PR #2: `chore/infra-stack-2-retry` ← adds workspace member + retry crate fix
- PR #3: `chore/infra-stack-3-stub-tests` ← stub integration tests for stub libs

## Verify
```bash
cargo check --workspace && cargo test -p phenotype-event-sourcing
```

Made with [Cursor](https://cursor.com)