### PR TITLE
fix(retry): add to workspace; replace invalid tenacity dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/phenotype-errors",
     "crates/phenotype-event-sourcing",
     "crates/phenotype-policy-engine",
+    "crates/phenotype-retry",
     "crates/phenotype-state-machine",
     "crates/phenotype-telemetry",
     "crates/phenotype-test-infra",

--- a/crates/phenotype-retry/Cargo.toml
+++ b/crates/phenotype-retry/Cargo.toml
@@ -12,22 +12,12 @@ repository.workspace = true
 description = "Retry patterns for Phenotype"
 
 [dependencies]
-# Retry library with backoff
-tenacity = { version = "0.3", features = ["nightly"] }
-
-# Async runtime
-tokio = { workspace = true, features = ["time"] }
-
-# Logging
+tokio = { workspace = true, features = ["time", "macros", "rt-multi-thread"] }
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util", "macros"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 
 [lib]
 path = "src/lib.rs"
-
-[[bin]]
-name = "retry-example"
-path = "examples/retry_example.rs"
-required-features = []

--- a/crates/phenotype-retry/src/builder.rs
+++ b/crates/phenotype-retry/src/builder.rs
@@ -1,15 +1,7 @@
 //! Retry builder for configuring retry behavior.
 
 use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
-
-use pin_project::pin_project;
-use tenacity::{Backoff, RetryForError, SystemClock};
-
-use crate::error::RetryError;
-use crate::RetryBuilder;
+use std::time::Duration;
 
 /// Maximum number of retry attempts
 const DEFAULT_MAX_ATTEMPTS: u32 = 3;
@@ -20,54 +12,53 @@ const DEFAULT_BASE_DELAY: Duration = Duration::from_millis(100);
 /// Maximum delay between retries
 const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(30);
 
-/// Builder for configuring retry behavior
-#[derive(Default, Debug, Clone)]
-pub struct RetryConfig {
-    pub max_attempts: u32,
-    pub base_delay: Duration,
-    pub max_delay: Duration,
-    pub jitter: bool,
-    pub timeout: Option<Duration>,
+/// Builder for configuring retry behavior.
+#[derive(Debug, Clone)]
+pub struct RetryBuilder {
+    max_attempts: u32,
+    base_delay: Duration,
+    max_delay: Duration,
+    jitter: bool,
 }
 
-impl RetryConfig {
-    /// Create a new retry config with default values
-    pub fn new() -> Self {
-        Self::default()
+impl Default for RetryBuilder {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            base_delay: DEFAULT_BASE_DELAY,
+            max_delay: DEFAULT_MAX_DELAY,
+            jitter: false,
+        }
     }
+}
 
-    /// Set maximum number of retry attempts
+impl RetryBuilder {
+    /// Set maximum number of retry attempts (clamped to at least 1).
     pub fn max_attempts(mut self, attempts: u32) -> Self {
-        self.max_attempts = attempts;
+        self.max_attempts = attempts.max(1);
         self
     }
 
-    /// Set base delay between retries
+    /// Set base delay between retries.
     pub fn base_delay(mut self, delay: Duration) -> Self {
         self.base_delay = delay;
         self
     }
 
-    /// Set maximum delay between retries
+    /// Set maximum delay between retries.
     pub fn max_delay(mut self, delay: Duration) -> Self {
         self.max_delay = delay;
         self
     }
 
-    /// Enable jitter for randomization
+    /// Enable deterministic jitter (spread based on attempt index; no extra deps).
     pub fn with_jitter(mut self) -> Self {
         self.jitter = true;
         self
     }
 
-    /// Set timeout for the entire operation
-    pub fn timeout(mut self, duration: Duration) -> Self {
-        self.timeout = Some(duration);
-        self
-    }
-
-    /// Execute an async operation with retry logic
-    pub async fn execute<F, Fut, T, E>(&self, f: F) -> Result<T, E>
+    /// Run an async operation with retries and exponential backoff.
+    pub async fn execute<F, Fut, T, E>(&self, mut f: F) -> Result<T, E>
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = Result<T, E>>,
@@ -78,20 +69,24 @@ impl RetryConfig {
         for attempt in 0..self.max_attempts {
             match f().await {
                 Ok(result) => return Ok(result),
-                Err(e) if attempt == self.max_attempts - 1 => return Err(e),
+                Err(e) if attempt + 1 >= self.max_attempts => return Err(e),
                 Err(_) => {
-                    if let Some(delay) = backoff.next_delay() {
+                    if let Some(mut delay) = backoff.next_delay() {
+                        if self.jitter {
+                            let extra_ms = (attempt.wrapping_mul(7919) % 50) as u64;
+                            delay += Duration::from_millis(extra_ms);
+                        }
                         tokio::time::sleep(delay).await;
                     }
                 }
             }
         }
 
-        unreachable!()
+        unreachable!("loop returns or errors within max_attempts")
     }
 }
 
-/// Exponential backoff calculator
+/// Exponential backoff calculator.
 #[derive(Debug, Clone)]
 pub struct ExponentialBackoff {
     current_delay: Duration,
@@ -101,7 +96,7 @@ pub struct ExponentialBackoff {
 }
 
 impl ExponentialBackoff {
-    /// Create a new backoff calculator
+    /// Create a new backoff calculator.
     pub fn new(base_delay: Duration, max_delay: Duration) -> Self {
         Self {
             current_delay: base_delay,
@@ -111,20 +106,18 @@ impl ExponentialBackoff {
         }
     }
 
-    /// Get the next delay value
+    /// Next delay before the following retry attempt.
     pub fn next_delay(&mut self) -> Option<Duration> {
-        if self.current_delay > self.max_delay {
+        let delay = self.current_delay;
+        let next_ms = (self.current_delay.as_millis() as f64 * self.multiplier) as u64;
+        self.current_delay = Duration::from_millis(next_ms).min(self.max_delay);
+        if delay > self.max_delay {
             return None;
         }
-
-        let delay = self.current_delay;
-        self.current_delay =
-            Duration::from_millis((self.current_delay.as_millis() as f64 * self.multiplier) as u64);
-        self.current_delay = self.current_delay.min(self.max_delay);
         Some(delay)
     }
 
-    /// Reset the backoff to initial state
+    /// Reset the backoff to its initial state.
     pub fn reset(&mut self) {
         self.current_delay = self.base_delay;
     }

--- a/crates/phenotype-retry/src/error.rs
+++ b/crates/phenotype-retry/src/error.rs
@@ -29,6 +29,10 @@ pub enum RetryError {
     #[error("operation failed: {0}")]
     OperationFailed(String),
 
+    /// Transient failure — caller may retry the operation.
+    #[error("transient: {0}")]
+    Transient(String),
+
     /// Maximum delay exceeded
     #[error("maximum delay ({max_delay:?}) exceeded")]
     MaxDelayExceeded {
@@ -60,13 +64,13 @@ impl RetryError {
     pub fn is_retriable(&self) -> bool {
         matches!(
             self,
-            Self::OperationFailed(_) | Self::MaxDelayExceeded { .. }
+            Self::OperationFailed(_) | Self::Transient(_) | Self::MaxDelayExceeded { .. }
         )
     }
 }
 
-impl From<std::time::Elapsed> for RetryError {
-    fn from(_: std::time::Elapsed) -> Self {
+impl From<tokio::time::error::Elapsed> for RetryError {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
         Self::Cancelled
     }
 }

--- a/crates/phenotype-retry/src/lib.rs
+++ b/crates/phenotype-retry/src/lib.rs
@@ -1,58 +1,29 @@
 //! # Phenotype Retry Library
 //!
-//! Provides retry patterns using the tenacity crate with exponential backoff.
-//!
-//! ## Features
-//!
-//! - Exponential backoff with configurable base delay
-//! - Jitter for randomization
-//! - Maximum retry attempts limit
-//! - Timeout support
-//! - Error filtering (only retry certain errors)
-//!
-//! ## Usage
-//!
-//! ```rust,ignore
-//! use phenotype_retry::retry;
-//! use std::time::Duration;
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let result = retry()
-//!         .max_attempts(3)
-//!         .base_delay(Duration::from_millis(100))
-//!         .execute(|| async {
-//!             // Your async operation here
-//!             Ok(())
-//!         })
-//!         .await;
-//!     Ok(result?)
-//! }
-//! ```
+//! Async retry helpers with exponential backoff (Tokio).
 
 pub mod builder;
 pub mod error;
 
-pub use builder::RetryBuilder;
+pub use builder::{ExponentialBackoff, RetryBuilder};
 pub use error::RetryError;
 
-// Re-export tenacity types for advanced usage
-pub use tenacity::Backoff;
+/// Backwards-compatible alias for [`ExponentialBackoff`].
+pub type Backoff = ExponentialBackoff;
 
-// Re-export commonly used types
 pub use std::time::Duration;
 
-/// Default retry builder with sensible defaults
+/// Default retry builder with sensible defaults.
 pub fn retry() -> RetryBuilder {
     RetryBuilder::default()
 }
 
-/// Create a retry builder with custom max attempts
+/// Create a retry builder with custom max attempts.
 pub fn retry_with_attempts(max_attempts: u32) -> RetryBuilder {
     RetryBuilder::default().max_attempts(max_attempts)
 }
 
-/// Create a retry builder with custom base delay
+/// Create a retry builder with custom base delay.
 pub fn retry_with_delay(base_delay: Duration) -> RetryBuilder {
     RetryBuilder::default().base_delay(base_delay)
 }
@@ -105,7 +76,7 @@ mod tests {
     async fn test_retry_exhausted() {
         static CALL_COUNT: AtomicU32 = AtomicU32::new(0);
 
-        let result = retry()
+        let result: Result<(), RetryError> = retry()
             .max_attempts(3)
             .base_delay(Duration::from_millis(10))
             .execute(|| async {


### PR DESCRIPTION
## Summary
**Stack 2/3** — builds on https://github.com/KooshaPari/phenotype-infrakit/pull/127

## Changes
- Add `crates/phenotype-retry` to workspace members.
- Replace nonexistent `tenacity` crates.io dep with an in-crate `RetryBuilder` + exponential backoff (`thiserror`, `tokio::time`).
- Add `RetryError::Transient`; fix `From` for `tokio::time::error::Elapsed`.

## Verify
```bash
cargo test -p phenotype-retry
```