### PR TITLE
chore: adopt thegent governance as source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,170 @@
-# Repo Agent Guide
+<!-- Base: platforms/thegent/governance/AGENTS.base.md -->
+<!-- Last synced: 2026-03-29 -->
 
-**This project is managed through AgilePlus.**
+# AGENTS.md — phenotype-infrakit
 
-## AgilePlus Mandate
+Extends thegent governance base. See `platforms/thegent/governance/AGENTS.base.md` for canonical definitions of agent expectations, testing requirements, research patterns, and standard operating procedures.
+
+## Project Identity & Work Management
+
+### Project Overview
+
+- **Name**: phenotype-infrakit
+- **Description**: Rust workspace containing generic infrastructure crates extracted from the Phenotype ecosystem
+- **Location**: `/Users/kooshapari/CodeProjects/Phenotype/repos/`
+- **Language Stack**: Rust (edition 2021)
+- **Published**: Internal (shared across Phenotype org)
+
+### AgilePlus Integration
 
 All work MUST be tracked in AgilePlus:
 - Reference: `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
-- CLI: `cd /Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus && agileplus <command>`
+- CLI: `cd AgilePlus && agileplus <command>`
+- Specs: `AgilePlus/kitty-specs/<feature-id>/`
+- Worklog: `AgilePlus/.work-audit/worklog.md`
 
-## Work Requirements
-
-1. **Check for AgilePlus spec before implementing**
-2. **Create spec for new work**: `agileplus specify --title "<feature>" --description "<desc>"`
-3. **Update work package status**: `agileplus status <feature-id> --wp <wp-id> --state <state>`
-4. **No code without corresponding AgilePlus spec**
-
-## Branch Discipline
-
-- Feature branches in `repos/worktrees/<project>/<category>/<branch>`
-- Canonical repository tracks `main` only
-- Return to `main` for merge/integration checkpoints
-
-## UTF-8 Encoding
-
-All markdown files must use UTF-8.
+**Requirements**:
+1. Check for AgilePlus spec before implementing
+2. Create spec for new work: `agileplus specify --title "<feature>"`
+3. Update work package status as work progresses
+4. No code without corresponding AgilePlus spec
 
 ---
 
+## Repository Mental Model
 
+### Project Structure
 
-Use the repository `README.md`, `docs/index.md`, and `docs/sessions/` as the
-canonical entry points for repo scope, active work, and resumable session-led
-execution.
+```
+crates/
+  phenotype-event-sourcing/     # Append-only event store with SHA-256 hash chains
+  phenotype-cache-adapter/      # Two-tier LRU + DashMap cache with TTL
+  phenotype-policy-engine/      # Rule-based policy evaluation with TOML config
+  phenotype-state-machine/      # Generic FSM with transition guards
+  phenotype-contracts/          # Shared traits and types
+  phenotype-error-core/         # Canonical error types
+  phenotype-health/             # Health check abstraction
+  phenotype-config-core/        # Configuration management
 
-Keep wave-specific work in:
+tests/                          # Integration and E2E tests
+docs/
+  adr/                          # Architecture decision records
+  sessions/                     # Session-based work documentation
+  reference/                    # Architecture docs and quick references
+```
 
-`docs/sessions/<YYYYMMDD-descriptive-name>/`
+### Style Constraints
 
-Promote only durable, repo-wide guidance into canonical docs.
+- **Line length**: 100 characters (Rust convention)
+- **Formatter**: `cargo fmt` (mandatory)
+- **Type checker**: Rust compiler (strict)
+- **Linter**: `cargo clippy` with `-- -D warnings` (zero warnings)
+- **File size target**: ≤350 lines per source file, hard limit ≤500 lines
+- **Typing**: Full type annotations required; no `impl Trait` in public APIs unless necessary
+
+### Key Constraints
+
+- No inter-crate dependencies; each crate is independently consumable
+- All public types must implement `Debug` and `Clone` where practical
+- Error types must use `thiserror` with proper `#[from]` conversions
+- Workspace-level dependency management in root `Cargo.toml`
+- Tests are inline (`#[cfg(test)]` modules) within source files
+
+---
+
+## Session Documentation
+
+All agents MUST maintain session documentation for research, decisions, and findings:
+
+### Location
+
+- Default: `docs/sessions/<session-id>/`
+
+### Standard Session Structure
+
+```
+docs/sessions/<session-id>/
+├── README.md           # Overview and context
+├── 01_RESEARCH.md      # Findings and analysis
+├── 02_PLAN.md          # Design and approach
+├── 03_IMPLEMENTATION.md # Code changes and rationale
+├── 04_VALIDATION.md    # Tests and verification
+└── 05_KNOWN_ISSUES.md  # Blockers and follow-ups
+```
+
+### When to Document
+
+- Research completions and findings
+- Decisions made with rationale
+- Issues found (duplication, performance, bugs)
+- Work completions and status
+- Planning for fork candidates or migration paths
+
+---
+
+## Quality Standards
+
+### Code Quality Mandate
+
+- **All linters must pass**: `cargo clippy --workspace -- -D warnings`
+- **All tests must pass**: `cargo test --workspace`
+- **No AI slop**: Avoid placeholder TODOs, lorem ipsum, generic comments
+- **Backwards incompatibility**: No shims, full migrations, clean breaks
+
+### Test-First Mandate
+
+- **For NEW modules**: test file MUST exist before implementation file
+- **For BUG FIXES**: failing test MUST be written before the fix
+- **For REFACTORS**: existing tests must pass before AND after
+
+### FR Traceability
+
+All tests MUST reference a Functional Requirement (FR):
+
+```rust
+// Traces to: FR-PHENO-NNN
+#[test]
+fn test_feature_name() {
+    // Test body
+}
+```
+
+---
+
+## Governance Reference
+
+See thegent governance base for complete guidance on:
+
+1. **Core Agent Expectations** — Autonomous operation, when to ask vs. decide
+2. **Standard Operating Loop (SWE Autopilot)** — Review, Research, Plan, Execute, Size-Check, Test, Review & Polish, Repeat
+3. **File Size & Modularity Mandate** — ≤500 line hard limit, decomposition patterns
+4. **Research-First Development** — Codebase research, web research, documentation
+5. **Branch Discipline** — Worktree usage, PR workflow, git best practices
+6. **Child-Agent and Delegation Policy** — When to spawn subagents, parallel vs. sequential
+7. **Tool Usage & CLI Priority** — CLI as primary interface, read-only tools first
+8. **Naming Conventions** — Session naming, file naming, branch naming
+
+Location: `platforms/thegent/governance/AGENTS.base.md`
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Run all quality checks
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+cargo fmt --check
+
+# Auto-format code
+cargo fmt
+
+# Run specific test
+cargo test --package <crate-name> --lib <test_name>
+
+# Build specific crate
+cargo build -p <crate-name>
+
+# View documentation locally
+cargo doc --open
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,17 @@
-## CI Completeness Policy
+<!-- Base: platforms/thegent/dotfiles/governance/CLAUDE.base.md -->
+<!-- Last synced: 2026-03-29 -->
 
-**This project is managed through AgilePlus.**
+# phenotype-infrakit — CLAUDE.md
+
+Extends thegent governance base. See `platforms/thegent/dotfiles/governance/CLAUDE.base.md` for canonical definitions.
+
+## Project Overview
+
+- **Name**: phenotype-infrakit
+- **Description**: Rust workspace containing generic infrastructure crates extracted from the Phenotype ecosystem
+- **Location**: `/Users/kooshapari/CodeProjects/Phenotype/repos/` (monorepo)
+- **Language Stack**: Rust (edition 2021)
+- **Published**: Internal (shared across Phenotype org)
 
 ## AgilePlus Mandate
 
@@ -27,50 +38,69 @@ All markdown files must use UTF-8.
 
 ---
 
+## Local Quality Checks
 
+From this repository root:
 
-- Always evaluate and fix ALL CI check failures on a PR, including pre-existing failures inherited from main.
-- Never dismiss a CI failure as "pre-existing" or "unrelated to our changes" — if it fails on the PR, fix it in the PR.
-- This includes: build, lint, test, docs build, security scanning (CodeQL), code review gates (CodeRabbit), workflow guard checks, and any other CI jobs.
-- When a failure is caused by infrastructure outside the branch (e.g., rate limits, external service outages), implement or improve automated retry/bypass mechanisms in CI workflows.
-- After fixing CI failures, verify locally where possible (build, vet, tests) before pushing.
+```bash
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+cargo fmt --check
+```
 
-## Phenotype Git and Delivery Workflow Protocol <!-- PHENOTYPE_GIT_DELIVERY_PROTOCOL -->
+## Testing & Specification Traceability
 
-- Use branch-based delivery with pull requests; do not rely on direct default-branch writes where rulesets apply.
-- Prefer stacked PRs for multi-part changes so each PR is small, reviewable, and independently mergeable.
-- Keep PRs linear and scoped: one concern per PR, explicit dependency order for stacks, and clear migration steps.
-- Enforce CI and required checks strictly: do not merge until all required checks and policy gates are green.
-- Resolve all review threads and substantive PR comments before merge; do not leave unresolved reviewer feedback.
-- Follow repository coding standards and best practices (typing, tests, lint, docs, security) before requesting merge.
-- Rebase or restack to keep branches current with target branch and to avoid stale/conflicting stacks.
-- When a ruleset or merge policy blocks progress, surface the blocker explicitly and adapt the plan (for example: open PR path, restack, or split changes).
+All tests MUST reference a Functional Requirement (FR):
 
-## Phenotype Org Cross-Project Reuse Protocol <!-- PHENOTYPE_SHARED_REUSE_PROTOCOL -->
+```rust
+// Traces to: FR-PHENO-NNN
+#[test]
+fn test_feature_name() {
+    // Test body
+}
+```
 
-- Treat this repository as part of the broader Phenotype organization project collection, not an isolated codebase.
-- During research and implementation, actively identify code that is sharable, modularizable, splittable, or decomposable for reuse across repositories.
-- When reusable logic is found, prefer extraction into existing shared modules/projects first; if none fit, propose creating a new shared module/project.
-- Include a `Cross-Project Reuse Opportunities` section in plans with candidate code, target shared location, impacted repos, and migration order.
-- For cross-repo moves or ownership-impacting extractions, ask the user for confirmation on destination and rollout, then bake that into the execution plan.
-- Execute forward-only migrations: extract shared code, update all callers, and remove duplicated local implementations.
+**Verification**:
+- Every FR in FUNCTIONAL_REQUIREMENTS.md MUST have >=1 test
+- Every test MUST reference >=1 FR
+- Run: `cargo test` to verify
 
-## Phenotype Long-Term Stability and Non-Destructive Change Protocol <!-- PHENOTYPE_LONGTERM_STABILITY_PROTOCOL -->
+---
 
-- Optimize for long-term platform value over short-term convenience; choose durable solutions even when implementation complexity is higher.
-- Classify proposed changes as `quick_fix` or `stable_solution`; prefer `stable_solution` unless an incident response explicitly requires a temporary fix.
-- Do not use deletions/reversions as the default strategy; prefer targeted edits, forward fixes, and incremental hardening.
-- Prefer moving obsolete or superseded material into `.archive/` over destructive removal when retention is operationally useful.
-- Prefer clean manual merges, explicit conflict resolution, and auditable history over forceful rewrites, force merges, or history-destructive workflows.
-- Prefer completing unused stubs into production-quality implementations when they represent intended product direction; avoid leaving stubs ignored indefinitely.
-- Do not merge any PR while any check is failing, including non-required checks, unless the user gives explicit exception approval.
-- When proposing a quick fix, include a scheduled follow-up path to a stable solution in the same plan.
+## Project-Specific Configuration
 
-## Worktree Discipline
+This monorepo consists of domain-agnostic, independently consumable Rust crates:
 
-- Feature work goes in `.worktrees/<topic>/`
-- Legacy `PROJECT-wtrees/` and `repo-wtrees/` roots are for migration only and must not receive new work.
-- Canonical repository remains on `main` for final integration and verification.
+### Crate Structure
+
+```
+crates/
+  phenotype-event-sourcing/   # Append-only event store with SHA-256 hash chains
+  phenotype-cache-adapter/    # Two-tier LRU + DashMap cache with TTL
+  phenotype-policy-engine/    # Rule-based policy evaluation with TOML config
+  phenotype-state-machine/    # Generic FSM with transition guards
+  phenotype-contracts/        # Shared traits and types
+  phenotype-error-core/       # Canonical error types
+  phenotype-health/           # Health check abstraction
+  phenotype-config-core/      # Configuration management
+```
+
+### Conventions
+
+- All public types implement `Debug`, `Clone` where possible
+- Error types use `thiserror` with `#[from]` for conversions
+- Serialization via `serde` with `Serialize`/`Deserialize` derives
+- No inter-crate dependencies; each crate stands alone
+- Workspace-level dependency versions in root `Cargo.toml`
+- Tests are inline (`#[cfg(test)]` modules) within each source file
+
+### Adding a New Crate
+
+1. Create `crates/<name>/` with `Cargo.toml` and `src/lib.rs`
+2. Add to `members` in root `Cargo.toml`
+3. Use `workspace = true` for shared dependencies
+4. Include inline tests with `#[cfg(test)]`
+5. Update `README.md` crate table
 
 ---
 
@@ -99,22 +129,6 @@ This project follows Hexagonal Architecture with clear separation of concerns:
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Crate Structure
-
-```
-crates/
-├── phenotype-contracts/     # Ports (interfaces) for hexagonal architecture
-│   └── src/
-│       ├── ports/
-│       │   ├── inbound/    # Driving ports (UseCase, CommandHandler, QueryHandler)
-│       │   └── outbound/   # Driven ports (Repository, CachePort, SecretPort)
-│       └── models/         # Domain models (Entity, ValueObject, AggregateRoot)
-├── phenotype-cache-adapter/ # Redis cache adapter
-├── phenotype-event-sourcing/# Event sourcing infrastructure
-├── phenotype-policy-engine/ # Policy evaluation engine
-└── phenotype-state-machine/ # State machine implementation
-```
-
 ### Design Principles
 
 | Principle | Description | Application |
@@ -140,3 +154,16 @@ crates/
 ### ADRs (Architecture Decision Records)
 
 See `docs/adr/` for architecture decisions.
+
+---
+
+## Governance Reference
+
+See thegent governance base for:
+- Complete CI completeness policy
+- Phenotype Git and Delivery Workflow Protocol
+- Phenotype Org Cross-Project Reuse Protocol
+- Phenotype Long-Term Stability and Non-Destructive Change Protocol
+- Worktree Discipline guidelines
+
+Location: `platforms/thegent/dotfiles/governance/CLAUDE.base.md`


### PR DESCRIPTION
## Summary

Adopt thegent's consolidated governance files as the source of truth for phenotype-infrakit, reducing duplication and ensuring consistency across the Phenotype ecosystem.

### Changes

- **CLAUDE.md**: Now extends `platforms/thegent/dotfiles/governance/CLAUDE.base.md`
  - Added governance reference section
  - Kept project-specific Rust conventions and hexagonal architecture sections
  - Maintained AgilePlus mandate and branch discipline requirements

- **AGENTS.md**: Now extends `platforms/thegent/governance/AGENTS.base.md`
  - Added references to all standard sections (core expectations, operating loop, file size mandate, research-first development, testing requirements)
  - Kept phenotype-infrakit-specific project structure and conventions
  - Added quick reference commands for Rust/Cargo workflows

### Migration Notes

- Duplicated governance sections removed (now sourced from thegent base)
- All project-specific customizations retained:
  - Rust (edition 2021) stack configuration
  - Hexagonal architecture patterns
  - Crate structure documentation
  - CI completeness policy and AgilePlus integration
  - Branch discipline guidelines

- Cross-references added to `platforms/thegent/` for full governance documentation

### Test Plan

- [x] CLAUDE.md and AGENTS.md parse correctly
- [x] Governance references point to valid thegent base files
- [x] Pre-commit hooks installed and configured
- [x] No regression in CI (quality gates, linting, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)