### PR TITLE
docs(governance): add TypeScript Zod and Python pydantic-settings standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,33 @@ crates/
 ### ADRs (Architecture Decision Records)
 
 See `docs/adr/` for architecture decisions.
+
+---
+
+## TypeScript Validation Standard
+
+All TypeScript projects use **Zod** (^3.24.2+) for runtime validation:
+
+- **React forms**: Use `@hookform/resolvers` for react-hook-form + Zod integration
+- **APIs**: Use `zod-to-json-schema` for JSON Schema generation from Zod schemas
+- **Schema location**: Define all validation schemas in `src/schemas/` directory
+- **Runtime validation**: Always use `.safeParse()` for validation with proper error handling
+- **No custom validators**: Use Zod's built-in methods and composable validators
+- **Type safety**: Leverage Zod's `z.infer<typeof schema>` for TypeScript type inference
+
+See `docs/reference/VALIDATION_STANDARDS.md` for detailed patterns and examples.
+
+---
+
+## Python Configuration Standard
+
+All Python projects use **pydantic-settings v2.x** for configuration management:
+
+- **Base pattern**: Composite `BaseSettings` with `SettingsConfigDict`
+- **Environment loading**: Auto `.env` loading via `env_file='.env'` in Config
+- **Field validators**: Use type hints, descriptions, and range validation on all config fields
+- **Consistent env prefix**: Define per-project prefix (e.g., `THGENT_*`, `AGILEPLUS_*`)
+- **Type safety**: All fields typed; use `Annotated` for validation metadata
+- **Immutability**: Configure `ConfigDict(frozen=True)` for production configs
+
+See `docs/reference/CONFIGURATION_STANDARDS.md` for detailed patterns and examples.


### PR DESCRIPTION
Add governance documentation for validation and configuration standards based on WS3 and WS5 audit findings.

## Changes

- **CLAUDE.md**: Added TypeScript Validation Standard section referencing Zod (^3.24.2+) and Python Configuration Standard section for pydantic-settings v2.x
- **docs/reference/VALIDATION_STANDARDS.md**: Comprehensive TypeScript validation guide with Zod patterns, schema organization, best practices, and integration with react-hook-form
- **docs/reference/CONFIGURATION_STANDARDS.md**: Complete Python configuration management guide for pydantic-settings v2.x with composite patterns, environment variables, and field validators

## Affected Projects

These standards apply to all TypeScript and Python projects in the Phenotype organization:
- TypeScript: All projects using zod for runtime validation
- Python: All projects using pydantic-settings for configuration

## Testing

Standards include examples for:
- React Hook Form integration with Zod
- JSON Schema generation
- Environment variable loading from .env files
- Configuration validation patterns
- Testing configuration objects

Closes #131 (TypeScript Zod audit WS3 findings)
Closes #132 (Python pydantic-settings audit WS5 findings)