### PR TITLE
ci(sbom): CycloneDX for full workspace (16 members)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,4 +1,4 @@
-# CycloneDX SBOM — workspace members (supply-chain artifacts).
+# CycloneDX SBOM — all Cargo workspace members (supply-chain artifacts).
 name: SBOM (CycloneDX pilot)
 
 on:
@@ -21,24 +21,51 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - id: phenotype-error-core
-            manifest: crates/phenotype-error-core/Cargo.toml
-            sbom_path: crates/phenotype-error-core/sbom-phenotype-error-core.json
-          - id: phenotype-contracts
-            manifest: crates/phenotype-contracts/Cargo.toml
-            sbom_path: crates/phenotype-contracts/sbom-phenotype-contracts.json
-          - id: phenotype-errors
-            manifest: crates/phenotype-errors/Cargo.toml
-            sbom_path: crates/phenotype-errors/sbom-phenotype-errors.json
-          - id: phenotype-event-sourcing
-            manifest: crates/phenotype-event-sourcing/Cargo.toml
-            sbom_path: crates/phenotype-event-sourcing/sbom-phenotype-event-sourcing.json
-          - id: phenotype-policy-engine
-            manifest: crates/phenotype-policy-engine/Cargo.toml
-            sbom_path: crates/phenotype-policy-engine/sbom-phenotype-policy-engine.json
+          - id: agileplus-api-types
+            manifest: crates/agileplus-api-types/Cargo.toml
+            sbom_path: crates/agileplus-api-types/sbom-agileplus-api-types.json
           - id: phenotype-cache-adapter
             manifest: crates/phenotype-cache-adapter/Cargo.toml
             sbom_path: crates/phenotype-cache-adapter/sbom-phenotype-cache-adapter.json
+          - id: phenotype-contracts
+            manifest: crates/phenotype-contracts/Cargo.toml
+            sbom_path: crates/phenotype-contracts/sbom-phenotype-contracts.json
+          - id: phenotype-crypto
+            manifest: crates/phenotype-crypto/Cargo.toml
+            sbom_path: crates/phenotype-crypto/sbom-phenotype-crypto.json
+          - id: phenotype-errors
+            manifest: crates/phenotype-errors/Cargo.toml
+            sbom_path: crates/phenotype-errors/sbom-phenotype-errors.json
+          - id: phenotype-error-core
+            manifest: crates/phenotype-error-core/Cargo.toml
+            sbom_path: crates/phenotype-error-core/sbom-phenotype-error-core.json
+          - id: phenotype-event-sourcing
+            manifest: crates/phenotype-event-sourcing/Cargo.toml
+            sbom_path: crates/phenotype-event-sourcing/sbom-phenotype-event-sourcing.json
+          - id: phenotype-iter
+            manifest: crates/phenotype-iter/Cargo.toml
+            sbom_path: crates/phenotype-iter/sbom-phenotype-iter.json
+          - id: phenotype-policy-engine
+            manifest: crates/phenotype-policy-engine/Cargo.toml
+            sbom_path: crates/phenotype-policy-engine/sbom-phenotype-policy-engine.json
+          - id: phenotype-port-traits
+            manifest: crates/phenotype-port-traits/Cargo.toml
+            sbom_path: crates/phenotype-port-traits/sbom-phenotype-port-traits.json
+          - id: phenotype-state-machine
+            manifest: crates/phenotype-state-machine/Cargo.toml
+            sbom_path: crates/phenotype-state-machine/sbom-phenotype-state-machine.json
+          - id: phenotype-string
+            manifest: crates/phenotype-string/Cargo.toml
+            sbom_path: crates/phenotype-string/sbom-phenotype-string.json
+          - id: phenotype-telemetry
+            manifest: crates/phenotype-telemetry/Cargo.toml
+            sbom_path: crates/phenotype-telemetry/sbom-phenotype-telemetry.json
+          - id: phenotype-test-infra
+            manifest: crates/phenotype-test-infra/Cargo.toml
+            sbom_path: crates/phenotype-test-infra/sbom-phenotype-test-infra.json
+          - id: phenotype-time
+            manifest: crates/phenotype-time/Cargo.toml
+            sbom_path: crates/phenotype-time/sbom-phenotype-time.json
           - id: phenotype-config-core
             manifest: libs/phenotype-config-core/Cargo.toml
             sbom_path: libs/phenotype-config-core/sbom-phenotype-config-core.json

--- a/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
+++ b/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
@@ -9,6 +9,7 @@ Land supply-chain automation as **small, reviewable PRs** (stacked / layered). *
 - Workflow `.github/workflows/sbom.yml` is on `main` from **[#95](https://github.com/KooshaPari/phenotype-infrakit/pull/95)** (earlier SBOM PR).
 - Stacked PRs **[#99](https://github.com/KooshaPari/phenotype-infrakit/pull/99)**–**[#101](https://github.com/KooshaPari/phenotype-infrakit/pull/101)** were **closed without merge**; this session doc and `DEPENDENCIES.md` pilot section were not on `main` until a **consolidated follow-up PR** (`chore/sbom-docs-session`) rebased onto current `main`.
 - **Consolidated PR** adds: `DEPENDENCIES.md` pilot documentation, this session note, and a **matrix** of CycloneDX jobs for seven workspace members (replacing the single-crate job while keeping the same workflow file).
+- **2026-03-31 follow-up:** matrix expanded to **all** `[workspace.members]` (16 CycloneDX jobs + matching artifacts).
 
 ## Stack (original plan — historical)
 
@@ -38,4 +39,4 @@ gh pr create --base main --head chore/sbom-docs-session --fill
 
 ---
 
-_Last updated: 2026-03-30_
+_Last updated: 2026-03-31_

--- a/docs/worklogs/DEPENDENCIES.md
+++ b/docs/worklogs/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Dependencies Worklogs
 
-**Category:** DEPENDENCIES | **Updated:** 2026-03-30 (SBOM pilot doc)
+**Category:** DEPENDENCIES | **Updated:** 2026-03-31 (SBOM full workspace matrix)
 
 ---
 
@@ -1823,7 +1823,7 @@ Create a unified dependency version policy:
 
 | Tool | Action |
 |------|--------|
-| `cargo-cyclonedx` | **PILOT:** `.github/workflows/sbom.yml` → artifacts `cyclonedx-sbom-<crate>` per matrix member (JSON spec 1.5); includes `phenotype-error-core`, contracts, errors, event-sourcing, policy-engine, cache-adapter, `phenotype-config-core` |
+| `cargo-cyclonedx` | **PILOT:** `.github/workflows/sbom.yml` → artifacts `cyclonedx-sbom-<crate-id>` per matrix row (JSON spec 1.5); matrix matches **all** root `Cargo.toml` `[workspace.members]` (including `libs/phenotype-config-core`) |
 | `syft` | WRAP in release pipeline |
 | OSV-Scanner | ADOPT for batch triage |
 | `cargo audit` + `cargo deny advisories` | Run both weekly |
@@ -1867,7 +1867,7 @@ Create a unified dependency version policy:
 | Workflow | `.github/workflows/sbom.yml` |
 | Triggers | `push` to `main`, `pull_request`, `workflow_dispatch` |
 | Tool | `cargo-cyclonedx@0.5.9` via `taiki-e/install-action` |
-| Scope | Matrix of workspace members (see workflow `matrix.include`) |
+| Scope | Full matrix: every `[workspace.members]` crate (16 rows; `fail-fast: false`) |
 | Output | One `sbom-<crate-id>.json` next to each crate manifest |
 | Artifact names | `cyclonedx-sbom-<crate-id>` (one upload per matrix row) |
 
@@ -1877,9 +1877,9 @@ Earlier stacked PRs (#99–#101) were closed without merge; workflow initially l
 
 ### Next expansions
 
-- [ ] Add remaining workspace members to the matrix (`agileplus-api-types`, crypto, iter, port-traits, state-machine, string, telemetry, test-infra, time).
+- [x] Add remaining workspace members to the matrix (full `[workspace.members]` coverage).
 - [ ] Attach SBOM to GitHub Releases for tagged builds (release workflow).
 
 ---
 
-_Last updated: 2026-03-30_
+_Last updated: 2026-03-31_


### PR DESCRIPTION
## Summary
Extends `.github/workflows/sbom.yml` so the CycloneDX matrix covers **every** entry in root `Cargo.toml` `[workspace.members]` (16 jobs, `fail-fast: false`).

## Docs
- `docs/worklogs/DEPENDENCIES.md` — supply-chain row, pilot table, and next-expansions checkbox aligned with full matrix.
- `docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md` — notes 2026-03-31 follow-up.

## Merge
Squash preferred; admin merge if Actions billing blocks checks.

Made with [Cursor](https://cursor.com)