### PR TITLE
feat(ci): add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,46 @@
+# CycloneDX SBOM pilot — single workspace member (supply-chain artifact).
+# Stacked delivery: land this workflow first; docs follow in a dependent PR.
+name: SBOM (CycloneDX pilot)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cyclonedx-phenotype-error-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-cyclonedx@0.5.9
+
+      - name: Generate CycloneDX JSON (pilot crate)
+        run: |
+          cargo cyclonedx \
+            --manifest-path crates/phenotype-error-core/Cargo.toml \
+            -f json \
+            --spec-version 1.5 \
+            --override-filename sbom-phenotype-error-core
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom-phenotype-error-core
+          path: crates/phenotype-error-core/sbom-phenotype-error-core.json
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ scripts/audit_scope.sh
 scripts/clone-devenv-abstraction-worktree.sh
 scripts/export_phenotype_session_artifacts.py
 scripts/git-worktree-health.sh
+.forge/
+.github/workflows/sbom.yml
+crates/agileplus-domain/
+docs/adoption/


### PR DESCRIPTION
## Summary
- Add CycloneDX SBOM generation CI workflow
- Update .gitignore for .forge/, sbom.yml, agileplus-domain/, docs/adoption/

## Test plan
- [ ] SBOM workflow generates valid CycloneDX output
- [ ] .gitignore changes don't exclude needed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)