### PR TITLE
feat(ci,sbom): script-driven workspace SBOMs + release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,38 @@ jobs:
           path: target/${{ matrix.target }}/release/agileplus
           retention-days: 5
 
+  # ─── CycloneDX SBOMs (attached to GitHub Release with binaries) ───────
+  cyclonedx-sboms:
+    name: CycloneDX SBOMs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-cyclonedx@0.5.9
+
+      - name: Generate workspace SBOMs
+        run: bash scripts/ci/generate-workspace-sboms.sh . sbom-out
+
+      - name: Upload SBOM bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom-workspace
+          path: sbom-out/cyclonedx-sbom-*.json
+          if-no-files-found: error
+          retention-days: 5
+
   # ─── Create GitHub Release ────────────────────────────────────────────
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build-release
+    needs:
+      - build-release
+      - cyclonedx-sboms
     permissions:
       contents: write
     steps:
@@ -89,6 +116,14 @@ jobs:
               cp "$binary_path" "./release-assets/agileplus-${target_name}"
             fi
           done
+          sbom_dir="./binaries/cyclonedx-sbom-workspace"
+          if [ -d "$sbom_dir" ]; then
+            shopt -s nullglob
+            for f in "$sbom_dir"/cyclonedx-sbom-*.json; do
+              cp "$f" ./release-assets/
+            done
+            shopt -u nullglob
+          fi
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -97,3 +132,6 @@ jobs:
           draft: false
           prerelease: false
           generateReleaseNotes: true
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,4 +1,5 @@
 # CycloneDX SBOM — all Cargo workspace members (supply-chain artifacts).
+# Crate list comes from `cargo metadata` via scripts/ci/generate-workspace-sboms.sh (no duplicated matrix).
 name: SBOM (CycloneDX pilot)
 
 on:
@@ -17,58 +18,6 @@ concurrency:
 jobs:
   cyclonedx:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - id: agileplus-api-types
-            manifest: crates/agileplus-api-types/Cargo.toml
-            sbom_path: crates/agileplus-api-types/sbom-agileplus-api-types.json
-          - id: phenotype-cache-adapter
-            manifest: crates/phenotype-cache-adapter/Cargo.toml
-            sbom_path: crates/phenotype-cache-adapter/sbom-phenotype-cache-adapter.json
-          - id: phenotype-contracts
-            manifest: crates/phenotype-contracts/Cargo.toml
-            sbom_path: crates/phenotype-contracts/sbom-phenotype-contracts.json
-          - id: phenotype-crypto
-            manifest: crates/phenotype-crypto/Cargo.toml
-            sbom_path: crates/phenotype-crypto/sbom-phenotype-crypto.json
-          - id: phenotype-errors
-            manifest: crates/phenotype-errors/Cargo.toml
-            sbom_path: crates/phenotype-errors/sbom-phenotype-errors.json
-          - id: phenotype-error-core
-            manifest: crates/phenotype-error-core/Cargo.toml
-            sbom_path: crates/phenotype-error-core/sbom-phenotype-error-core.json
-          - id: phenotype-event-sourcing
-            manifest: crates/phenotype-event-sourcing/Cargo.toml
-            sbom_path: crates/phenotype-event-sourcing/sbom-phenotype-event-sourcing.json
-          - id: phenotype-iter
-            manifest: crates/phenotype-iter/Cargo.toml
-            sbom_path: crates/phenotype-iter/sbom-phenotype-iter.json
-          - id: phenotype-policy-engine
-            manifest: crates/phenotype-policy-engine/Cargo.toml
-            sbom_path: crates/phenotype-policy-engine/sbom-phenotype-policy-engine.json
-          - id: phenotype-port-traits
-            manifest: crates/phenotype-port-traits/Cargo.toml
-            sbom_path: crates/phenotype-port-traits/sbom-phenotype-port-traits.json
-          - id: phenotype-state-machine
-            manifest: crates/phenotype-state-machine/Cargo.toml
-            sbom_path: crates/phenotype-state-machine/sbom-phenotype-state-machine.json
-          - id: phenotype-string
-            manifest: crates/phenotype-string/Cargo.toml
-            sbom_path: crates/phenotype-string/sbom-phenotype-string.json
-          - id: phenotype-telemetry
-            manifest: crates/phenotype-telemetry/Cargo.toml
-            sbom_path: crates/phenotype-telemetry/sbom-phenotype-telemetry.json
-          - id: phenotype-test-infra
-            manifest: crates/phenotype-test-infra/Cargo.toml
-            sbom_path: crates/phenotype-test-infra/sbom-phenotype-test-infra.json
-          - id: phenotype-time
-            manifest: crates/phenotype-time/Cargo.toml
-            sbom_path: crates/phenotype-time/sbom-phenotype-time.json
-          - id: phenotype-config-core
-            manifest: libs/phenotype-config-core/Cargo.toml
-            sbom_path: libs/phenotype-config-core/sbom-phenotype-config-core.json
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,17 +30,12 @@ jobs:
         with:
           tool: cargo-cyclonedx@0.5.9
 
-      - name: Generate CycloneDX JSON
-        run: |
-          cargo cyclonedx \
-            --manifest-path "${{ matrix.manifest }}" \
-            -f json \
-            --spec-version 1.5 \
-            --override-filename "sbom-${{ matrix.id }}"
+      - name: Generate workspace SBOMs
+        run: bash scripts/ci/generate-workspace-sboms.sh . sbom-out
 
-      - name: Upload SBOM artifact
+      - name: Upload SBOM bundle
         uses: actions/upload-artifact@v4
         with:
-          name: cyclonedx-sbom-${{ matrix.id }}
-          path: ${{ matrix.sbom_path }}
+          name: cyclonedx-sbom-workspace
+          path: sbom-out/cyclonedx-sbom-*.json
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/sbom-out/
 Cargo.lock
 *.swp
 *.swo

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,11 @@ tasks:
     cmds:
       - cargo build --release
 
+  sbom:
+    desc: Generate CycloneDX JSON for all workspace crates (needs cargo-cyclonedx@0.5.x and jq)
+    cmds:
+      - bash scripts/ci/generate-workspace-sboms.sh . sbom-out
+
   build:watch:
     desc: Build with file watcher
     cmds:

--- a/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
+++ b/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
@@ -8,8 +8,9 @@ Land supply-chain automation as **small, reviewable PRs** (stacked / layered). *
 
 - Workflow `.github/workflows/sbom.yml` is on `main` from **[#95](https://github.com/KooshaPari/phenotype-infrakit/pull/95)** (earlier SBOM PR).
 - Stacked PRs **[#99](https://github.com/KooshaPari/phenotype-infrakit/pull/99)**–**[#101](https://github.com/KooshaPari/phenotype-infrakit/pull/101)** were **closed without merge**; this session doc and `DEPENDENCIES.md` pilot section were not on `main` until a **consolidated follow-up PR** (`chore/sbom-docs-session`) rebased onto current `main`.
-- **Consolidated PR** adds: `DEPENDENCIES.md` pilot documentation, this session note, and a **matrix** of CycloneDX jobs for seven workspace members (replacing the single-crate job while keeping the same workflow file).
-- **2026-03-31 follow-up:** matrix expanded to **all** `[workspace.members]` (16 CycloneDX jobs + matching artifacts).
+- **Consolidated PR** ([#139](https://github.com/KooshaPari/phenotype-infrakit/pull/139)) adds: `DEPENDENCIES.md` pilot documentation, this session note, and an expanded CycloneDX workflow (later superseded by script-driven generation + release assets).
+- **2026-03-31 follow-up:** matrix expanded to **all** `[workspace.members]` (16 CycloneDX jobs + matching artifacts); see [#160](https://github.com/KooshaPari/phenotype-infrakit/pull/160).
+- **2026-03-31 (continued):** `scripts/ci/generate-workspace-sboms.sh` replaces duplicated workflow matrix; `sbom.yml` uploads one bundle; `release.yml` attaches the same CycloneDX JSON files to **GitHub Releases** for `v*.*.*` tags (with safe `allowUpdates` when `tag-automation.yml` created the release first).
 
 ## Stack (original plan — historical)
 
@@ -33,8 +34,8 @@ gh pr create --base main --head chore/sbom-docs-session --fill
 
 ## Success criteria
 
-- [x] `sbom.yml` on `main` generates CycloneDX JSON (matrix); workflow runs when Actions billing allows.
-- [x] Artifacts `cyclonedx-sbom-<crate-id>` for each matrix row.
+- [x] `sbom.yml` on `main` generates CycloneDX JSON for every workspace member; workflow runs when Actions billing allows.
+- [x] CI artifact bundle `cyclonedx-sbom-workspace`; tagged releases include the same JSON files as downloadable assets.
 - [x] `DEPENDENCIES.md` and session doc aligned with workflow behavior.
 
 ---

--- a/docs/worklogs/DEPENDENCIES.md
+++ b/docs/worklogs/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Dependencies Worklogs
 
-**Category:** DEPENDENCIES | **Updated:** 2026-03-31 (SBOM full workspace matrix)
+**Category:** DEPENDENCIES | **Updated:** 2026-03-31 (SBOM script + release assets)
 
 ---
 
@@ -1823,7 +1823,7 @@ Create a unified dependency version policy:
 
 | Tool | Action |
 |------|--------|
-| `cargo-cyclonedx` | **PILOT:** `.github/workflows/sbom.yml` → artifacts `cyclonedx-sbom-<crate-id>` per matrix row (JSON spec 1.5); matrix matches **all** root `Cargo.toml` `[workspace.members]` (including `libs/phenotype-config-core`) |
+| `cargo-cyclonedx` | **PILOT:** `scripts/ci/generate-workspace-sboms.sh` drives `.github/workflows/sbom.yml` (CI artifact `cyclonedx-sbom-workspace`) and `.github/workflows/release.yml` (same JSONs attached to **GitHub Releases** on `v*.*.*` tags alongside binaries) |
 | `syft` | WRAP in release pipeline |
 | OSV-Scanner | ADOPT for batch triage |
 | `cargo audit` + `cargo deny advisories` | Run both weekly |
@@ -1867,9 +1867,11 @@ Create a unified dependency version policy:
 | Workflow | `.github/workflows/sbom.yml` |
 | Triggers | `push` to `main`, `pull_request`, `workflow_dispatch` |
 | Tool | `cargo-cyclonedx@0.5.9` via `taiki-e/install-action` |
-| Scope | Full matrix: every `[workspace.members]` crate (16 rows; `fail-fast: false`) |
-| Output | One `sbom-<crate-id>.json` next to each crate manifest |
-| Artifact names | `cyclonedx-sbom-<crate-id>` (one upload per matrix row) |
+| Crate list | `cargo metadata --no-deps` (always matches `[workspace.members]`) |
+| Generator | `scripts/ci/generate-workspace-sboms.sh` → flat `cyclonedx-sbom-<crate>.json` files |
+| CI artifact | `cyclonedx-sbom-workspace` (all JSONs in one bundle) |
+| Releases | `release.yml` uploads the same files as release assets; `ncipollo/release-action` uses `allowUpdates` + `omitBodyDuringUpdate` / `omitNameDuringUpdate` so releases created by `tag-automation.yml` keep their body while assets are added |
+| Local | `task sbom` (requires `cargo-cyclonedx` + `jq`) |
 
 ### Stacked delivery (historical)
 
@@ -1878,7 +1880,7 @@ Earlier stacked PRs (#99–#101) were closed without merge; workflow initially l
 ### Next expansions
 
 - [x] Add remaining workspace members to the matrix (full `[workspace.members]` coverage).
-- [ ] Attach SBOM to GitHub Releases for tagged builds (release workflow).
+- [x] Attach SBOM to GitHub Releases for tagged builds (`release.yml` + `cyclonedx-sboms` job).
 
 ---
 

--- a/scripts/ci/generate-workspace-sboms.sh
+++ b/scripts/ci/generate-workspace-sboms.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Generate CycloneDX JSON (spec 1.5) for every package in the repo root Cargo workspace.
+# Used by .github/workflows/sbom.yml and release.yml — single source of truth vs duplicating matrix YAML.
+#
+# Usage: generate-workspace-sboms.sh [REPO_ROOT] [OUTPUT_DIR]
+#   REPO_ROOT   — directory containing root Cargo.toml (default: .)
+#   OUTPUT_DIR  — flat directory for cyclonedx-sbom-<crate>.json (default: sbom-out)
+#
+# Requires: cargo, cargo-cyclonedx on PATH, jq.
+set -euo pipefail
+
+ROOT="${1:-.}"
+OUT_DIR="${2:-sbom-out}"
+
+cd "$ROOT"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "generate-workspace-sboms.sh: jq is required" >&2
+  exit 1
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "generate-workspace-sboms.sh: cargo is required" >&2
+  exit 1
+fi
+
+if ! cargo cyclonedx --version >/dev/null 2>&1; then
+  echo "generate-workspace-sboms.sh: cargo-cyclonedx is required (cargo install cargo-cyclonedx --version 0.5.9)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+while IFS=$'\t' read -r name path; do
+  [[ -z "${name:-}" ]] || [[ -z "${path:-}" ]] && continue
+  path=$(realpath "$path")
+  echo "SBOM: ${name} (${path})"
+  cargo cyclonedx \
+    --manifest-path "$path" \
+    -f json \
+    --spec-version 1.5 \
+    --override-filename "sbom-${name}"
+  mdir=$(dirname "$path")
+  src="${mdir}/sbom-${name}.json"
+  if [[ ! -f "$src" ]]; then
+    echo "generate-workspace-sboms.sh: expected output missing: ${src}" >&2
+    exit 1
+  fi
+  cp "$src" "${OUT_DIR}/cyclonedx-sbom-${name}.json"
+done < <(cargo metadata --no-deps --format-version 1 | jq -r '
+  .workspace_members[] as $id
+  | .packages[]
+  | select(.id == $id)
+  | "\(.name)\t\(.manifest_path)"
+')
+
+shopt -s nullglob
+files=("${OUT_DIR}"/cyclonedx-sbom-*.json)
+if [[ ${#files[@]} -lt 1 ]]; then
+  echo "generate-workspace-sboms.sh: no SBOM files produced under ${OUT_DIR}" >&2
+  exit 1
+fi
+echo "generate-workspace-sboms.sh: wrote ${#files[@]} file(s) to ${OUT_DIR}"


### PR DESCRIPTION
## Summary
- **Single source of truth:** `scripts/ci/generate-workspace-sboms.sh` enumerates `[workspace.members]` via `cargo metadata` and runs `cargo-cyclonedx` (spec 1.5) for each crate into flat `cyclonedx-sbom-<crate>.json` files.
- **`sbom.yml`:** one job uploads bundle artifact `cyclonedx-sbom-workspace` (replaces duplicated 16-row matrix YAML).
- **`release.yml`:** new `cyclonedx-sboms` job (parallel with binaries); `create-release` copies those JSONs into `release-assets` so GitHub Releases include SBOMs for `v*.*.*` tags.
- **ncipollo/release-action:** `allowUpdates: true` + `omitBodyDuringUpdate` / `omitNameDuringUpdate` so a release created first by `tag-automation.yml` keeps its body while assets are appended.
- **`task sbom`**, `/sbom-out/` in `.gitignore`, `DEPENDENCIES.md` + session doc updates.

## Merge
Squash; admin merge if Actions billing blocks checks.

Made with [Cursor](https://cursor.com)