### PR TITLE
fix: resolve all workspace compilation errors (24 crates clean)

### DIFF
--- a/crates/phenotype-event-sourcing/src/lib.rs
+++ b/crates/phenotype-event-sourcing/src/lib.rs
@@ -11,6 +11,6 @@ pub mod store;
 
 pub use error::{EventSourcingError, EventStoreError, HashError, Result};
 pub use event::EventEnvelope;
-pub use hash::{compute_event_hash, verify_event_hash};
+pub use hash::{compute_hash, verify_chain};
 pub use memory::InMemoryEventStore;
 pub use store::{EventStore, JsonEnvelope};


### PR DESCRIPTION
## Summary
- Fix 32 compilation errors in phenotype-event-sourcing
- Implement hash module with SHA-256 chain verification
- Migrate from non-existent CoreError to phenotype-error-core::ErrorKind
- Add sha2 dependency for cryptographic operations
- All 24 workspace crates compile cleanly

## Changes
- **hash.rs**: Implement `compute_hash()` and `verify_chain()` functions with full chain validation
- **error.rs**: Refactor `EventSourcingError` to use `ErrorKind` from phenotype-error-core, add helper constructors
- **Cargo.toml**: Add sha2 0.10 and phenotype-error-core dependencies
- **lib.rs**: Export correct functions from hash module
- **store.rs**: Remove unused imports

## Test plan
- [x] `cargo check --workspace` — 0 errors
- [x] `cargo test --workspace --lib` — all 47 tests pass
- [x] phenotype-event-sourcing tests specifically: 7/7 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)