### PR TITLE
chore: remove unused import warning in event-sourcing

### DIFF
--- a/crates/phenotype-event-sourcing/src/store.rs
+++ b/crates/phenotype-event-sourcing/src/store.rs
@@ -1,7 +1,6 @@
 //! EventStore trait — generic append-only event storage.
 
 use chrono::{DateTime, Utc};
-use serde::Serialize;
 
 use crate::error::Result;
 use crate::event::EventEnvelope;


### PR DESCRIPTION
## Summary
- Remove unused `serde::Serialize` import from `phenotype-event-sourcing/src/store.rs`
- Workspace now compiles with zero warnings

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)