### PR TITLE
feat(phenotype-crypto): implement hashing and content-addressable IDs

### DIFF
--- a/crates/phenotype-crypto/Cargo.toml
+++ b/crates/phenotype-crypto/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "phenotype-crypto"
-version = "0.2.0"
-edition = "2021"
-authors = ["Phenotype Team"]
-license = "MIT"
-description = "Crypto for Phenotype"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Cryptographic utilities for Phenotype — hashing, hex encoding, and content addressing"
+
+[dependencies]
+sha2.workspace = true
+hex.workspace = true
+blake3.workspace = true
+thiserror.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/phenotype-crypto/src/hash.rs
+++ b/crates/phenotype-crypto/src/hash.rs
@@ -1,0 +1,82 @@
+//! Hashing utilities — SHA-256 and Blake3.
+
+use sha2::{Digest, Sha256};
+
+/// Supported hash algorithms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashAlgorithm {
+    Sha256,
+    Blake3,
+}
+
+/// Compute SHA-256 hash of bytes, returned as hex string.
+pub fn sha256_hash(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+/// Compute Blake3 hash of bytes, returned as hex string.
+pub fn blake3_hash(data: &[u8]) -> String {
+    let hash = blake3::hash(data);
+    hash.to_hex().to_string()
+}
+
+/// Compute a content-addressable ID using the specified algorithm.
+/// Format: `{algorithm}:{hex_hash}`
+pub fn content_id(data: &[u8], algorithm: HashAlgorithm) -> String {
+    match algorithm {
+        HashAlgorithm::Sha256 => format!("sha256:{}", sha256_hash(data)),
+        HashAlgorithm::Blake3 => format!("blake3:{}", blake3_hash(data)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_known_vector() {
+        // SHA-256 of empty string
+        let hash = sha256_hash(b"");
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_hello() {
+        let hash = sha256_hash(b"hello");
+        assert_eq!(
+            hash,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn blake3_deterministic() {
+        let h1 = blake3_hash(b"test data");
+        let h2 = blake3_hash(b"test data");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // 32 bytes = 64 hex chars
+    }
+
+    #[test]
+    fn content_id_format() {
+        let id = content_id(b"payload", HashAlgorithm::Sha256);
+        assert!(id.starts_with("sha256:"));
+        assert_eq!(id.len(), 7 + 64); // "sha256:" + 64 hex
+
+        let id = content_id(b"payload", HashAlgorithm::Blake3);
+        assert!(id.starts_with("blake3:"));
+        assert_eq!(id.len(), 7 + 64);
+    }
+
+    #[test]
+    fn different_algorithms_produce_different_hashes() {
+        let s = sha256_hash(b"same input");
+        let b = blake3_hash(b"same input");
+        assert_ne!(s, b);
+    }
+}

--- a/crates/phenotype-crypto/src/lib.rs
+++ b/crates/phenotype-crypto/src/lib.rs
@@ -1,1 +1,8 @@
-//\! `phenotype-crypto` stub.
+//! # Phenotype Crypto
+//!
+//! Cryptographic utilities: hashing (SHA-256, Blake3), hex encoding,
+//! and content-addressable identifiers.
+
+pub mod hash;
+
+pub use hash::{blake3_hash, content_id, sha256_hash, HashAlgorithm};


### PR DESCRIPTION
## Summary
- Implement `phenotype-crypto` crate (was empty stub)
- SHA-256 and Blake3 hash functions returning hex strings
- Content-addressable ID generation (`sha256:abc123...` format)
- `HashAlgorithm` enum for algorithm selection
- 5 unit tests including known SHA-256 vectors

## Test plan
- [x] `cargo test -p phenotype-crypto` — 5/5 pass
- [x] `cargo check` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)