### PR TITLE
feat(phenotype-port-traits): implement hexagonal architecture ports

### DIFF
--- a/crates/phenotype-port-traits/Cargo.toml
+++ b/crates/phenotype-port-traits/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "phenotype-port-traits"
-version = "0.2.0"
-edition = "2021"
-authors = ["Phenotype Team"]
-license = "MIT"
-description = "Phenotype Port-traits"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Hexagonal architecture port traits for Phenotype — repository, event store, notification interfaces"
+
+[dependencies]
+async-trait.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/phenotype-port-traits/src/lib.rs
+++ b/crates/phenotype-port-traits/src/lib.rs
@@ -1,1 +1,70 @@
-// phenotype-port-traits
+//! # Phenotype Port Traits
+//!
+//! Hexagonal architecture port interfaces for Phenotype.
+//!
+//! Defines the contracts between domain logic and infrastructure adapters:
+//! - [`Repository`] — CRUD persistence
+//! - [`EventPublisher`] / [`EventSubscriber`] — event-driven messaging
+//! - [`Notifier`] — notification delivery
+//! - [`CachePort`] — caching abstraction
+
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Generic repository port for aggregate persistence.
+#[async_trait]
+pub trait Repository<T: Send + Sync>: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn get(&self, id: &str) -> Result<Option<T>, Self::Error>;
+    async fn save(&self, id: &str, entity: &T) -> Result<(), Self::Error>;
+    async fn delete(&self, id: &str) -> Result<(), Self::Error>;
+    async fn list(&self, offset: usize, limit: usize) -> Result<Vec<T>, Self::Error>;
+    async fn exists(&self, id: &str) -> Result<bool, Self::Error> {
+        Ok(self.get(id).await?.is_some())
+    }
+}
+
+/// Event publisher port — outbound events.
+#[async_trait]
+pub trait EventPublisher: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn publish(&self, topic: &str, payload: &serde_json::Value) -> Result<(), Self::Error>;
+}
+
+/// Event subscriber port — inbound events.
+#[async_trait]
+pub trait EventSubscriber: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn subscribe(
+        &self,
+        topic: &str,
+        handler: Box<dyn Fn(serde_json::Value) + Send + Sync>,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Notification delivery port.
+#[async_trait]
+pub trait Notifier: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn notify(&self, recipient: &str, subject: &str, body: &str)
+        -> Result<(), Self::Error>;
+}
+
+/// Cache port for key-value caching.
+#[async_trait]
+pub trait CachePort: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn get<T: DeserializeOwned + Send>(&self, key: &str) -> Result<Option<T>, Self::Error>;
+    async fn set<T: Serialize + Send + Sync>(
+        &self,
+        key: &str,
+        value: &T,
+        ttl_secs: Option<u64>,
+    ) -> Result<(), Self::Error>;
+    async fn delete(&self, key: &str) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
## Summary
- Implement `phenotype-port-traits` crate (was empty stub)
- `Repository` — async CRUD persistence with generic errors and default `exists()` impl
- `EventPublisher` / `EventSubscriber` — event-driven messaging ports
- `Notifier` — notification delivery port
- `CachePort` — key-value caching with TTL support
- All traits are `Send + Sync` with associated `Error` types

## Test plan
- [x] `cargo check -p phenotype-port-traits` — compiles clean
- [x] Zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)