### PR TITLE
ci: single release owner; OSV-Scanner + Syft SPDX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,39 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+  # ─── Syft SPDX (complements CycloneDX per-crate JSON) ─────────────────
+  syft-spdx:
+    name: Syft SPDX (workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Syft
+        env:
+          SYFT_SEMVER: 1.42.3
+        run: |
+          curl -fsSL "https://github.com/anchore/syft/releases/download/v${SYFT_SEMVER}/syft_${SYFT_SEMVER}_linux_amd64.tar.gz" | tar xz
+          sudo install -m 0755 syft /usr/local/bin/syft
+
+      - name: Generate SPDX JSON (repo tree)
+        run: |
+          mkdir -p sbom-out
+          syft . \
+            -o spdx-json=sbom-out/syft-spdx-workspace.json \
+            --exclude './target/**' \
+            --exclude './docs/**' \
+            --exclude './**/.venv/**' \
+            --exclude './**/node_modules/**' \
+            --exclude './.git/**'
+
+      - name: Upload SPDX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: syft-spdx-workspace
+          path: sbom-out/syft-spdx-workspace.json
+          if-no-files-found: error
+          retention-days: 5
+
   # ─── Create GitHub Release ────────────────────────────────────────────
   create-release:
     name: Create GitHub Release
@@ -96,6 +129,7 @@ jobs:
     needs:
       - build-release
       - cyclonedx-sboms
+      - syft-spdx
     permissions:
       contents: write
     steps:
@@ -124,6 +158,12 @@ jobs:
             done
             shopt -u nullglob
           fi
+          syft_dir="./binaries/syft-spdx-workspace"
+          if [ -d "$syft_dir" ]; then
+            for f in "$syft_dir"/*.json; do
+              [ -f "$f" ] && cp "$f" ./release-assets/
+            done
+          fi
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -132,6 +172,7 @@ jobs:
           draft: false
           prerelease: false
           generateReleaseNotes: true
+          # Re-runs / human-edited releases: keep title & body; still refresh assets list.
           allowUpdates: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -84,3 +84,25 @@ jobs:
       - name: Run bandit
         run: bandit -r python/src -ll
         continue-on-error: true
+
+  # ─── OSV-Scanner (Rust lockfile; repo does not commit Cargo.lock) ───────
+  osv-scanner:
+    name: OSV Scanner (Cargo.lock)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Generate Cargo.lock for scanning
+        run: cargo generate-lockfile
+      - name: Install OSV-Scanner
+        env:
+          OSV_VERSION: v2.3.5
+        run: |
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_linux_amd64"
+          chmod +x /tmp/osv-scanner
+          sudo mv /tmp/osv-scanner /usr/local/bin/osv-scanner
+      - name: Scan with OSV.dev
+        run: osv-scanner scan -L Cargo.lock --format table

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -67,15 +67,11 @@ jobs:
           git push origin "$TAG"
           echo "Created and pushed tag: $TAG"
 
-      - name: Create release
+      # GitHub Release (binaries + CycloneDX SBOMs) is owned solely by
+      # .github/workflows/release.yml on tag push — avoids racing softprops here.
+      - name: Release workflow will run for new tag
         if: steps.check_tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
-          body: |
-            Automated release for version ${{ steps.version.outputs.version }}
-          draft: false
-          prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "Pushed v${VERSION}. The Release workflow creates the GitHub Release and assets."

--- a/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
+++ b/docs/sessions/20260330-stacked-pr-sbom/00_OVERVIEW.md
@@ -10,7 +10,9 @@ Land supply-chain automation as **small, reviewable PRs** (stacked / layered). *
 - Stacked PRs **[#99](https://github.com/KooshaPari/phenotype-infrakit/pull/99)**–**[#101](https://github.com/KooshaPari/phenotype-infrakit/pull/101)** were **closed without merge**; this session doc and `DEPENDENCIES.md` pilot section were not on `main` until a **consolidated follow-up PR** (`chore/sbom-docs-session`) rebased onto current `main`.
 - **Consolidated PR** ([#139](https://github.com/KooshaPari/phenotype-infrakit/pull/139)) adds: `DEPENDENCIES.md` pilot documentation, this session note, and an expanded CycloneDX workflow (later superseded by script-driven generation + release assets).
 - **2026-03-31 follow-up:** matrix expanded to **all** `[workspace.members]` (16 CycloneDX jobs + matching artifacts); see [#160](https://github.com/KooshaPari/phenotype-infrakit/pull/160).
-- **2026-03-31 (continued):** `scripts/ci/generate-workspace-sboms.sh` replaces duplicated workflow matrix; `sbom.yml` uploads one bundle; `release.yml` attaches the same CycloneDX JSON files to **GitHub Releases** for `v*.*.*` tags (with safe `allowUpdates` when `tag-automation.yml` created the release first).
+- **2026-03-31 (continued):** `scripts/ci/generate-workspace-sboms.sh` replaces duplicated workflow matrix; `sbom.yml` uploads one bundle; `release.yml` attaches the same CycloneDX JSON files to **GitHub Releases** for `v*.*.*` tags; see **[#191](https://github.com/KooshaPari/phenotype-infrakit/pull/191)**.
+- **Tag vs release:** `tag-automation.yml` now **only** pushes `v*` tags when `Cargo.toml` / `package.json` version changes on `main`; **`.github/workflows/release.yml`** is the sole creator of GitHub Releases (removes race with `softprops/action-gh-release`).
+- **Supply-chain “next”:** `security.yml` adds **OSV-Scanner** on a generated `Cargo.lock`; `release.yml` adds **Syft** SPDX JSON next to CycloneDX assets on each version tag.
 
 ## Stack (original plan — historical)
 

--- a/docs/worklogs/DEPENDENCIES.md
+++ b/docs/worklogs/DEPENDENCIES.md
@@ -1903,8 +1903,8 @@ Create a unified dependency version policy:
 | Tool | Action |
 |------|--------|
 | `cargo-cyclonedx` | **PILOT:** `scripts/ci/generate-workspace-sboms.sh` drives `.github/workflows/sbom.yml` (CI artifact `cyclonedx-sbom-workspace`) and `.github/workflows/release.yml` (same JSONs attached to **GitHub Releases** on `v*.*.*` tags alongside binaries) |
-| `syft` | WRAP in release pipeline |
-| OSV-Scanner | ADOPT for batch triage |
+| `syft` | **PILOT:** `.github/workflows/release.yml` → job `syft-spdx` → SPDX JSON `syft-spdx-workspace.json` on GitHub Releases (with CycloneDX crate SBOMs) |
+| OSV-Scanner | **ADOPT:** `.github/workflows/security.yml` → job `osv-scanner` (`cargo generate-lockfile` + `osv-scanner scan -L Cargo.lock`; same schedule as Security workflow) |
 | `cargo audit` + `cargo deny advisories` | Run both weekly |
 
 ### Black-box wraps
@@ -1949,8 +1949,10 @@ Create a unified dependency version policy:
 | Crate list | `cargo metadata --no-deps` (always matches `[workspace.members]`) |
 | Generator | `scripts/ci/generate-workspace-sboms.sh` → flat `cyclonedx-sbom-<crate>.json` files |
 | CI artifact | `cyclonedx-sbom-workspace` (all JSONs in one bundle) |
-| Releases | `release.yml` uploads the same files as release assets; `ncipollo/release-action` uses `allowUpdates` + `omitBodyDuringUpdate` / `omitNameDuringUpdate` so releases created by `tag-automation.yml` keep their body while assets are added |
+| Releases | `tag-automation.yml` **only** creates/pushes `v*` tags from `main`; `release.yml` **creates** the GitHub Release (binaries + per-crate CycloneDX JSON + SPDX from Syft). `ncipollo/release-action` keeps `allowUpdates` + `omitBodyDuringUpdate` / `omitNameDuringUpdate` for workflow re-runs and manual title/body edits |
 | Local | `task sbom` (requires `cargo-cyclonedx` + `jq`) |
+| OSV.dev | `security.yml` job `osv-scanner` — `cargo generate-lockfile` then `osv-scanner scan -L Cargo.lock` (pinned binary v2.3.5) |
+| SPDX (Syft) | `release.yml` job `syft-spdx` — Syft v1.42.3, `syft .` → `syft-spdx-workspace.json` (excludes `target`, `docs`, venvs, `node_modules`, `.git`) |
 
 ### Stacked delivery (historical)
 
@@ -1960,6 +1962,9 @@ Earlier stacked PRs (#99–#101) were closed without merge; workflow initially l
 
 - [x] Add remaining workspace members to the matrix (full `[workspace.members]` coverage).
 - [x] Attach SBOM to GitHub Releases for tagged builds (`release.yml` + `cyclonedx-sboms` job).
+- [x] Single owner for GitHub Releases: `tag-automation.yml` pushes tags only; `release.yml` creates the release (no duplicate `softprops/action-gh-release`).
+- [x] **OSV-Scanner** on generated `Cargo.lock` in `security.yml` (alongside existing `cargo audit` / `cargo deny`).
+- [x] **Syft** SPDX JSON on tagged releases (`release.yml` `syft-spdx` job).
 
 ---
 


### PR DESCRIPTION
## Summary
Completes the remaining supply-chain / release follow-ups.

### Tag automation
- **Remove** `softprops/action-gh-release` from `tag-automation.yml`. The workflow **only** creates and pushes `v*` tags when version bumps land on `main`.
- **`release.yml`** remains the **sole** creator of GitHub Releases (binaries + SBOM assets), avoiding a race with a second release creator.

### Security (`security.yml`)
- New job **`osv-scanner`**: `cargo generate-lockfile` (repo does not commit `Cargo.lock`) then **OSV-Scanner** v2.3.5, `osv-scanner scan -L Cargo.lock`. Runs on the same triggers as the existing Security workflow (including daily schedule).

### Release (`release.yml`)
- New job **`syft-spdx`**: **Syft** v1.42.3, `syft .` → `syft-spdx-workspace.json` with excludes for `target`, `docs`, venvs, `node_modules`, `.git`.
- `create-release` copies that SPDX file into release assets alongside CycloneDX JSON + binaries.

### Docs
- `docs/worklogs/DEPENDENCIES.md` and session `00_OVERVIEW.md` updated; next-expansion checkboxes for OSV/Syft/single-release-owner marked done.

## Merge
Squash; admin merge if Actions billing blocks checks.

Made with [Cursor](https://cursor.com)