### PR TITLE
fix: resolve workspace build errors in cache-adapter and event-sourcing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ git2 = "0.20"
 syn = { version = "2", features = ["full", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
+dashmap = "6"
+lru = "0.14"
+moka = { version = "0.12", features = ["sync"] }
 
 [profile.dev]
 opt-level = 0

--- a/crates/phenotype-cache-adapter/Cargo.toml
+++ b/crates/phenotype-cache-adapter/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
 name = "phenotype-cache-adapter"
-version = "0.2.0"
-edition = "2021"
-authors = ["Phenotype Team"]
-license = "MIT"
-description = "Phenotype Cache-adapter"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Two-tier cache adapter (L1 LRU + L2 Moka) for Phenotype"
+
+[dependencies]
+chrono.workspace = true
+dashmap.workspace = true
+lru.workspace = true
+moka.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+phenotype-error-core = { path = "../phenotype-error-core" }
 
 [lib]
 path = "src/lib.rs"
-
-[dependencies]
-phenotype-error-core = { version = "0.1.0", path = "../phenotype-error-core" }

--- a/crates/phenotype-cache-adapter/src/lib.rs
+++ b/crates/phenotype-cache-adapter/src/lib.rs
@@ -3,14 +3,13 @@
 //! Two-tier cache with L1 (LRU) and L2 (DashMap/Moka).
 
 use chrono::{DateTime, Duration, Utc};
-use dashmap::DashMap;
 use lru::LruCache;
 use moka::sync::Cache as MokaCache;
 use phenotype_error_core::ErrorKind;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 pub type Result<T> = std::result::Result<T, ErrorKind>;
 

--- a/crates/phenotype-event-sourcing/src/error.rs
+++ b/crates/phenotype-event-sourcing/src/error.rs
@@ -119,12 +119,12 @@ impl std::error::Error for HashError {}
 
 impl From<EventStoreError> for EventSourcingError {
     fn from(e: EventStoreError) -> Self {
-        Self(e.to_string())
+        Self(ErrorKind::storage(e.to_string()))
     }
 }
 
 impl From<HashError> for EventSourcingError {
     fn from(e: HashError) -> Self {
-        Self(e.to_string())
+        Self(ErrorKind::internal(e.to_string()))
     }
 }


### PR DESCRIPTION
## Summary
- Add `dashmap`, `lru`, `moka` to workspace dependencies
- Wire `phenotype-cache-adapter` deps to workspace (was using unresolved crate imports)
- Fix `EventSourcingError` `From` impls: wrap in `ErrorKind` instead of raw `String`
- Remove unused imports (`DashMap`, `RwLock`), add missing `Deserialize` import
- **Result: 28 crates, zero errors, zero warnings, all tests pass**

## Test plan
- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo test` — all pass (53+ tests across workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependencies for caching and concurrent data structures management.
  * Streamlined workspace dependency configuration across crates.

* **Refactor**
  * Improved error handling with explicit categorization for different error types.
  * Cleaned up unused imports and simplified internal code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->