### PR TITLE
feat: implement config-core and agileplus-domain (last stubs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ scripts/export_phenotype_session_artifacts.py
 scripts/git-worktree-health.sh
 .forge/
 .github/workflows/sbom.yml
-crates/agileplus-domain/
 docs/adoption/
 cargo-check.log
 docs/worklogs/libification/CODE_QUALITY_METRICS.md

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "agileplus-domain"
-version = "0.2.0"
-edition = "2021"
-authors = ["Phenotype Team"]
-license = "MIT"
-description = "Agileplus-domain"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "AgilePlus domain model — entities, value objects, and port interfaces"
+
+[dependencies]
+serde.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+async-trait.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/agileplus-domain/src/entities.rs
+++ b/crates/agileplus-domain/src/entities.rs
@@ -1,0 +1,99 @@
+//! Domain entities for AgilePlus.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::values::{Priority, Status};
+
+/// A project in AgilePlus.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A work item (epic, story, task) in a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkItem {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub title: String,
+    pub description: String,
+    pub status: Status,
+    pub priority: Priority,
+    pub assignee: Option<String>,
+    pub parent_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A sprint / iteration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sprint {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub name: String,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+    pub goal: String,
+}
+
+impl Project {
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            name: name.into(),
+            description: description.into(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+impl WorkItem {
+    pub fn new(
+        project_id: Uuid,
+        title: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            project_id,
+            title: title.into(),
+            description: description.into(),
+            status: Status::Backlog,
+            priority: Priority::Medium,
+            assignee: None,
+            parent_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_project() {
+        let p = Project::new("Test", "A test project");
+        assert_eq!(p.name, "Test");
+        assert!(!p.id.is_nil());
+    }
+
+    #[test]
+    fn create_work_item() {
+        let p = Project::new("P", "desc");
+        let wi = WorkItem::new(p.id, "Task 1", "Do something");
+        assert_eq!(wi.project_id, p.id);
+        assert_eq!(wi.status, Status::Backlog);
+        assert_eq!(wi.priority, Priority::Medium);
+    }
+}

--- a/crates/agileplus-domain/src/lib.rs
+++ b/crates/agileplus-domain/src/lib.rs
@@ -1,3 +1,7 @@
-// agileplus-domain
+//! # AgilePlus Domain
+//!
+//! Core domain model for AgilePlus: entities, value objects, and port interfaces.
 
+pub mod entities;
 pub mod ports;
+pub mod values;

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -1,1 +1,38 @@
-// ports module
+//! Port interfaces for AgilePlus domain.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::entities::{Project, Sprint, WorkItem};
+
+/// Project repository port.
+#[async_trait]
+pub trait ProjectRepository: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn get(&self, id: &Uuid) -> Result<Option<Project>, Self::Error>;
+    async fn save(&self, project: &Project) -> Result<(), Self::Error>;
+    async fn list(&self) -> Result<Vec<Project>, Self::Error>;
+    async fn delete(&self, id: &Uuid) -> Result<(), Self::Error>;
+}
+
+/// Work item repository port.
+#[async_trait]
+pub trait WorkItemRepository: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn get(&self, id: &Uuid) -> Result<Option<WorkItem>, Self::Error>;
+    async fn save(&self, item: &WorkItem) -> Result<(), Self::Error>;
+    async fn list_by_project(&self, project_id: &Uuid) -> Result<Vec<WorkItem>, Self::Error>;
+    async fn delete(&self, id: &Uuid) -> Result<(), Self::Error>;
+}
+
+/// Sprint repository port.
+#[async_trait]
+pub trait SprintRepository: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn get(&self, id: &Uuid) -> Result<Option<Sprint>, Self::Error>;
+    async fn save(&self, sprint: &Sprint) -> Result<(), Self::Error>;
+    async fn list_by_project(&self, project_id: &Uuid) -> Result<Vec<Sprint>, Self::Error>;
+}

--- a/crates/agileplus-domain/src/values.rs
+++ b/crates/agileplus-domain/src/values.rs
@@ -1,0 +1,47 @@
+//! Value objects for AgilePlus domain.
+
+use serde::{Deserialize, Serialize};
+
+/// Work item status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Status {
+    Backlog,
+    Todo,
+    InProgress,
+    InReview,
+    Done,
+    Cancelled,
+}
+
+/// Work item priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Priority {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Backlog => write!(f, "backlog"),
+            Self::Todo => write!(f, "todo"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::InReview => write!(f, "in_review"),
+            Self::Done => write!(f, "done"),
+            Self::Cancelled => write!(f, "cancelled"),
+        }
+    }
+}
+
+impl std::fmt::Display for Priority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Critical => write!(f, "critical"),
+            Self::High => write!(f, "high"),
+            Self::Medium => write!(f, "medium"),
+            Self::Low => write!(f, "low"),
+        }
+    }
+}

--- a/libs/phenotype-config-core/src/lib.rs
+++ b/libs/phenotype-config-core/src/lib.rs
@@ -1,1 +1,142 @@
-//\! phenotype-config-core stub.
+//! # Phenotype Config Core
+//!
+//! Minimal, composable config loading for Phenotype crates.
+//!
+//! Loads TOML config from a cascade of sources:
+//! 1. System config (`/etc/phenotype/<name>.toml`)
+//! 2. User config (`~/.config/phenotype/<name>.toml`)
+//! 3. Project config (`./<name>.toml`)
+//! 4. Custom paths via `with_path()`
+
+use serde::de::DeserializeOwned;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("toml parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    #[error("config not found at any search path")]
+    NotFound,
+}
+
+pub type Result<T> = std::result::Result<T, ConfigError>;
+
+/// Config loader with cascading source resolution.
+pub struct ConfigLoader {
+    name: String,
+    search_paths: Vec<PathBuf>,
+}
+
+impl ConfigLoader {
+    /// Create a new config loader for the given config name (e.g. "agileplus").
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let mut search_paths = Vec::new();
+
+        // System config
+        search_paths.push(PathBuf::from(format!("/etc/phenotype/{name}.toml")));
+
+        // User config
+        if let Some(config_dir) = dirs::config_dir() {
+            search_paths.push(config_dir.join("phenotype").join(format!("{name}.toml")));
+        }
+
+        // Project config (cwd)
+        search_paths.push(PathBuf::from(format!("{name}.toml")));
+
+        Self { name, search_paths }
+    }
+
+    /// Add a custom search path.
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        let pos = self.search_paths.len().saturating_sub(1);
+        self.search_paths.insert(pos, path.into());
+        self
+    }
+
+    /// Load and deserialize config from the first found file.
+    pub fn load<T: DeserializeOwned>(&self) -> Result<T> {
+        for path in &self.search_paths {
+            if path.exists() {
+                let content = std::fs::read_to_string(path)?;
+                let config: T = toml::from_str(&content)?;
+                return Ok(config);
+            }
+        }
+        Err(ConfigError::NotFound)
+    }
+
+    /// Load from a specific file path.
+    pub fn load_from<T: DeserializeOwned>(path: &Path) -> Result<T> {
+        let content = std::fs::read_to_string(path)?;
+        let config: T = toml::from_str(&content)?;
+        Ok(config)
+    }
+
+    /// Return the list of paths that will be searched.
+    pub fn search_paths(&self) -> &[PathBuf] {
+        &self.search_paths
+    }
+
+    /// Get the config name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::io::Write;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestConfig {
+        name: String,
+        port: u16,
+    }
+
+    #[test]
+    fn load_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "name = \"myapp\"\nport = 8080").unwrap();
+
+        let config: TestConfig = ConfigLoader::load_from(&path).unwrap();
+        assert_eq!(config.name, "myapp");
+        assert_eq!(config.port, 8080);
+    }
+
+    #[test]
+    fn not_found() {
+        let loader = ConfigLoader::new("nonexistent-config-xyz");
+        let result: Result<TestConfig> = loader.load();
+        assert!(matches!(result, Err(ConfigError::NotFound)));
+    }
+
+    #[test]
+    fn custom_search_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("custom.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "name = \"custom\"\nport = 3000").unwrap();
+
+        let loader = ConfigLoader::new("custom").with_path(dir.path().join("custom.toml"));
+        let config: TestConfig = loader.load().unwrap();
+        assert_eq!(config.name, "custom");
+        assert_eq!(config.port, 3000);
+    }
+
+    #[test]
+    fn search_paths_populated() {
+        let loader = ConfigLoader::new("test");
+        assert!(!loader.search_paths().is_empty());
+        assert_eq!(loader.name(), "test");
+    }
+}


### PR DESCRIPTION
## Summary
Implements the last two stub crates in the workspace:

### phenotype-config-core
- Cascading TOML config loader (system → user → project)
- Custom search path injection via `with_path()`
- Direct file loading via `load_from()`
- 4 tests

### agileplus-domain
- Core entities: `Project`, `WorkItem`, `Sprint` with constructor helpers
- Value objects: `Status` (6 states), `Priority` (4 levels) with Display impls
- Port interfaces: `ProjectRepository`, `WorkItemRepository`, `SprintRepository`
- Un-ignores `crates/agileplus-domain/` from `.gitignore`
- 2 tests

**Result: All 28 workspace crates now have real implementations. Zero stubs remaining.**

## Test plan
- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)