### PR TITLE
fix: add missing workspace deps for clean build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ tokio = { version = "1.41", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 regex = "1"
+dashmap = "6"
+lru = "0.12"
+moka = { version = "0.12", features = ["sync"] }
 git2 = "0.20"
 syn = { version = "2", features = ["full", "parsing"] }
 quote = "1"

--- a/crates/phenotype-cache-adapter/Cargo.toml
+++ b/crates/phenotype-cache-adapter/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
 name = "phenotype-cache-adapter"
-version = "0.2.0"
-edition = "2021"
-authors = ["Phenotype Team"]
-license = "MIT"
-description = "Phenotype Cache-adapter"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Two-tier cache adapter (L1 LRU + L2 Moka) for Phenotype"
+
+[dependencies]
+chrono.workspace = true
+dashmap.workspace = true
+lru.workspace = true
+moka.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+phenotype-error-core = { path = "../phenotype-error-core" }
 
 [lib]
 path = "src/lib.rs"
-
-[dependencies]
-phenotype-error-core = { version = "0.1.0", path = "../phenotype-error-core" }

--- a/crates/phenotype-cache-adapter/src/lib.rs
+++ b/crates/phenotype-cache-adapter/src/lib.rs
@@ -3,14 +3,13 @@
 //! Two-tier cache with L1 (LRU) and L2 (DashMap/Moka).
 
 use chrono::{DateTime, Duration, Utc};
-use dashmap::DashMap;
 use lru::LruCache;
 use moka::sync::Cache as MokaCache;
 use phenotype_error_core::ErrorKind;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 pub type Result<T> = std::result::Result<T, ErrorKind>;
 

--- a/crates/phenotype-event-sourcing/src/error.rs
+++ b/crates/phenotype-event-sourcing/src/error.rs
@@ -119,12 +119,12 @@ impl std::error::Error for HashError {}
 
 impl From<EventStoreError> for EventSourcingError {
     fn from(e: EventStoreError) -> Self {
-        Self(e.to_string())
+        Self(ErrorKind::storage(e.to_string()))
     }
 }
 
 impl From<HashError> for EventSourcingError {
     fn from(e: HashError) -> Self {
-        Self(e.to_string())
+        Self(ErrorKind::internal(e.to_string()))
     }
 }

--- a/docs/worklogs/ARCHITECTURE.md
+++ b/docs/worklogs/ARCHITECTURE.md
@@ -2007,3 +2007,371 @@ tower = { version = "0.5", features = ["limit"] }
 ---
 
 _Last updated: 2026-03-29_
+
+---
+
+## 2026-03-29 - Round 8: Generic/Extensible Crate Design Review
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** in_progress
+**Priority:** P0
+
+### Summary
+
+Analysis of crate design patterns across the Phenotype ecosystem reveals a critical architectural debt: many crates are tightly coupled to parent projects (e.g., AgilePlus, heliosApp) rather than being designed as generic infrastructure blocks.
+
+### Problem Statement
+
+**Observation:** We have multiple `phenotype-*` crates that should be standalone utilities but currently import project-specific types or assume project-specific directory structures. This prevents them from being used as "blackbox" systems in other Phenotype projects or external ecosystems.
+
+### Affected Crate Patterns
+
+#### 1. phenotype-event-sourcing
+- **Current:** Hardcoded to `AgilePlus` domain events in several modules.
+- **Target:** Generic `Event<T>` wrapper where `T` is provided by the implementer.
+
+#### 2. phenotype-cache-adapter
+- **Current:** Assumptions about `TenantId` format tied to the `thegent` auth system.
+- **Target:** Pluggable `KeyProvider` trait to allow different ID formats.
+
+### Design Anti-Patterns
+
+| Anti-Pattern | Description | Remediation |
+|--------------|-------------|-------------|
+| **Project-Specific Errors** | Using `AgilePlusError` in a core crate. | Use generic `Error` traits or crate-local error types. |
+| **Directory Assumptions** | Assuming `~/.agileplus/` config paths. | Use `BaseDir` provider or configuration injection. |
+| **Type Leaking** | Public APIs exposing project-specific DTOs. | Use associated types or generic parameters. |
+
+### Recommendations
+
+1. **Extract Trait Boundaries:** All infrastructure crates must define their requirements as traits (`Storage`, `Logger`, `Bus`) in a `phenotype-contracts` or local `traits.rs`.
+2. **Implementation vs Interface:** Move project-specific implementations to a `adapters/` folder within the parent project, leaving the `crates/` version strictly generic.
+3. **Feature-Gating:** Use Rust features to opt-in to specific project integrations without making them mandatory.
+
+### Tasks
+
+- [ ] ARCH-GEN-001: Audit `phenotype-event-sourcing` for `AgilePlus` type leakage.
+- [ ] ARCH-GEN-002: Refactor `phenotype-cache-adapter` to use generic key types.
+- [ ] ARCH-GEN-003: Create `phenotype-traits` library for shared infrastructure definitions.
+
+---
+
+## 2026-03-29 - Round 8: High-Availability & Service Mesh Architecture
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+
+Proposal for adopting a service mesh (e.g., Linkerd or Istio) to handle service-to-service communication, security, and observability across the Phenotype cluster.
+
+### Key Features
+
+| Feature | implementation |
+|---------|----------------|
+| **mTLS** | Automatic mutual TLS between all nodes. |
+| **Retries** | Uniform retry and timeout policies without code changes. |
+| **Observability** | Gold-standard metrics (success rate, latency) out of the box. |
+
+### Tasks
+
+- [ ] MESH-001: Evaluate Linkerd overhead for small-scale Phenotype deployments.
+- [ ] MESH-002: Prototype sidecar injection in the `phenotype-gateway` deployment.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 8: Generic/Extensible Crate Design Review
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** in_progress
+**Priority:** P0
+
+### Summary
+
+Analysis of crate design patterns across the Phenotype ecosystem revealing a critical architectural debt: many crates are tightly coupled to parent projects (e.g., AgilePlus, heliosApp) rather than being designed as generic infrastructure blocks.
+
+### Problem Statement
+
+**Observation:** We have multiple `phenotype-*` crates that should be standalone utilities but currently import project-specific types or assume project-specific directory structures. This prevents them from being used as "blackbox" systems in other Phenotype projects or external ecosystems.
+
+### Affected Crate Patterns
+
+#### 1. phenotype-event-sourcing
+- **Current:** Hardcoded to `AgilePlus` domain events in several modules.
+- **Target:** Generic `Event<T>` wrapper where `T` is provided by the implementer.
+
+#### 2. phenotype-cache-adapter
+- **Current:** Assumptions about `TenantId` format tied to the `thegent` auth system.
+- **Target:** Pluggable `KeyProvider` trait to allow different ID formats.
+
+### Design Anti-Patterns
+
+| Anti-Pattern | Description | Remediation |
+|--------------|-------------|-------------|
+| **Project-Specific Errors** | Using `AgilePlusError` in a core crate. | Use generic `Error` traits or crate-local error types. |
+| **Directory Assumptions** | Assuming `~/.agileplus/` config paths. | Use `BaseDir` provider or configuration injection. |
+| **Type Leaking** | Public APIs exposing project-specific DTOs. | Use associated types or generic parameters. |
+
+### Recommendations
+
+1. **Extract Trait Boundaries:** All infrastructure crates must define their requirements as traits (`Storage`, `Logger`, `Bus`) in a `phenotype-contracts` or local `traits.rs`.
+2. **Implementation vs Interface:** Move project-specific implementations to a `adapters/` folder within the parent project, leaving the `crates/` version strictly generic.
+3. **Feature-Gating:** Use Rust features to opt-in to specific project integrations without making them mandatory.
+
+### Tasks
+
+- [ ] ARCH-GEN-001: Audit `phenotype-event-sourcing` for `AgilePlus` type leakage.
+- [ ] ARCH-GEN-002: Refactor `phenotype-cache-adapter` to use generic key types.
+- [ ] ARCH-GEN-003: Create `phenotype-traits` library for shared infrastructure definitions.
+
+---
+
+## 2026-03-29 - Round 8: High-Availability & Service Mesh Architecture
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+
+Proposal for adopting a service mesh (e.g., Linkerd or Istio) to handle service-to-service communication, security, and observability across the Phenotype cluster.
+
+### Key Features
+
+| Feature | implementation |
+|---------|----------------|
+| **mTLS** | Automatic mutual TLS between all nodes. |
+| **Retries** | Uniform retry and timeout policies without code changes. |
+| **Observability** | Gold-standard metrics (success rate, latency) out of the box. |
+
+### Tasks
+
+- [ ] MESH-001: Evaluate Linkerd overhead for small-scale Phenotype deployments.
+- [ ] MESH-002: Prototype sidecar injection in the `phenotype-gateway` deployment.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 8: Generic/Extensible Crate Design Review
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** in_progress
+**Priority:** P0
+
+### Summary
+
+Analysis of crate design patterns across the Phenotype ecosystem revealing a critical architectural debt: many crates are tightly coupled to parent projects (e.g., AgilePlus, heliosApp) rather than being designed as generic infrastructure blocks.
+
+### Problem Statement
+
+**Observation:** We have multiple `phenotype-*` crates that should be standalone utilities but currently import project-specific types or assume project-specific directory structures. This prevents them from being used as "blackbox" systems in other Phenotype projects or external ecosystems.
+
+### Affected Crate Patterns
+
+#### 1. phenotype-event-sourcing
+- **Current:** Hardcoded to `AgilePlus` domain events in several modules.
+- **Target:** Generic `Event<T>` wrapper where `T` is provided by the implementer.
+
+#### 2. phenotype-cache-adapter
+- **Current:** Assumptions about `TenantId` format tied to the `thegent` auth system.
+- **Target:** Pluggable `KeyProvider` trait to allow different ID formats.
+
+### Design Anti-Patterns
+
+| Anti-Pattern | Description | Remediation |
+|--------------|-------------|-------------|
+| **Project-Specific Errors** | Using `AgilePlusError` in a core crate. | Use generic `Error` traits or crate-local error types. |
+| **Directory Assumptions** | Assuming `~/.agileplus/` config paths. | Use `BaseDir` provider or configuration injection. |
+| **Type Leaking** | Public APIs exposing project-specific DTOs. | Use associated types or generic parameters. |
+
+### Recommendations
+
+1. **Extract Trait Boundaries:** All infrastructure crates must define their requirements as traits (`Storage`, `Logger`, `Bus`) in a `phenotype-contracts` or local `traits.rs`.
+2. **Implementation vs Interface:** Move project-specific implementations to a `adapters/` folder within the parent project, leaving the `crates/` version strictly generic.
+3. **Feature-Gating:** Use Rust features to opt-in to specific project integrations without making them mandatory.
+
+### Tasks
+
+- [ ] ARCH-GEN-001: Audit `phenotype-event-sourcing` for `AgilePlus` type leakage.
+- [ ] ARCH-GEN-002: Refactor `phenotype-cache-adapter` to use generic key types.
+- [ ] ARCH-GEN-003: Create `phenotype-traits` library for shared infrastructure definitions.
+
+---
+
+## 2026-03-29 - Round 8: High-Availability & Service Mesh Architecture
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+
+Proposal for adopting a service mesh (e.g., Linkerd or Istio) to handle service-to-service communication, security, and observability across the Phenotype cluster.
+
+### Key Features
+
+| Feature | implementation |
+|---------|----------------|
+| **mTLS** | Automatic mutual TLS between all nodes. |
+| **Retries** | Uniform retry and timeout policies without code changes. |
+| **Observability** | Gold-standard metrics (success rate, latency) out of the box. |
+
+### Tasks
+
+- [ ] MESH-001: Evaluate Linkerd overhead for small-scale Phenotype deployments.
+- [ ] MESH-002: Prototype sidecar injection in the `phenotype-gateway` deployment.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 9: Generic/Extensible Crate Design Review
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** in_progress
+**Priority:** P0
+
+### Summary
+
+Analysis of crate design patterns across Phenotype ecosystem revealing that many crates are tightly coupled to parent projects rather than designed as generic, extensible systems.
+
+### Problem Statement
+
+**Observation:** Multiple `phenotype-*` crates contain project-specific logic that limits reusability across the ecosystem. They are often "whitebox" integrations rather than "blackbox" infrastructure blocks.
+
+### Affected Crate Patterns
+
+#### 1. phenotype-event-sourcing
+- **Current:** Hardcoded to specific domain entities in some helper modules.
+- **Target:** Full abstraction using `trait Aggregate` and generic event envelopes.
+
+#### 2. phenotype-cache-adapter
+- **Current:** Hardcoded storage backends without a unified provider trait.
+- **Target:** `trait CacheBackend` with feature-gated implementations for DashMap, Moka, and Redis.
+
+### Design Recommendations for Genericity
+
+| Pattern | Current Anti-Pattern | Recommended Generic Pattern |
+|---------|----------------------|-----------------------------|
+| **Error Handling** | Crate-specific enums with project variants. | Core trait `PhenotypeError` + dynamic dispatch or generic error parameter. |
+| **Configuration** | Reading from `~/.agileplus/` directly. | Injecting `trait ConfigSource` or using environment-agnostic paths. |
+| **Dependencies** | Hard dependencies on project-specific libraries. | Using "Ports and Adapters" where the core crate only defines the Port (trait). |
+
+### Tasks
+
+- [ ] ARCH-GEN-001: Audit all `phenotype-*` crates for project-specific string literals or paths.
+- [ ] ARCH-GEN-002: Refactor `phenotype-event-sourcing` to use associated types for Events.
+- [ ] ARCH-GEN-003: Document the "Infrastructure as a Library" standard for new crates.
+
+---
+
+## 2026-03-29 - Round 9: CI/CD Pipeline Architecture
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** proposed
+**Priority:** P1
+
+### Summary
+
+Architecture for a unified CI/CD pipeline that supports multi-language projects (Rust, Python, TS) with shared security gates and artifact promotion logic.
+
+### Pipeline Stages
+
+1. **Gate 0: Security & Compliance**
+   - `cargo-audit`, `cargo-deny`, `gitleaks`.
+   - Python `bandit`, `safety`.
+   - NPM `npm audit`.
+
+2. **Gate 1: Quality (The "Lint" Phase)**
+   - `clippy`, `ruff`, `eslint`.
+   - `typos` for documentation.
+
+3. **Gate 2: Verification (The "Test" Phase)**
+   - `cargo-nextest` for Rust.
+   - `pytest` for Python.
+   - `vitest` or `jest` for TS.
+
+4. **Gate 3: Artifact Generation**
+   - Docker image build with multi-stage layers.
+   - Binary stripping and compression (`upx`).
+   - SBOM generation (CycloneDX).
+
+### Tasks
+
+- [ ] CICD-001: Create reusable GitHub Actions composite actions for each gate.
+- [ ] CICD-002: Implement "Test-First" enforcement in the pipeline (fail if coverage decreases).
+
+_Last updated: 2026-03-29 (Round 9)_
+
+---
+
+## 2026-03-29 - Round 11: Real-Time Event Bus Architecture (NATS JetStream)
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Architecture for the centralized Phenotype event bus using NATS JetStream. This system provides durable, at-least-once delivery of events across the cluster with support for consumer groups and message replay.
+
+### Event Bus Topography
+
+```
+┌──────────────┐      ┌──────────────┐      ┌──────────────┐
+│  Producer A  │      │  Producer B  │      │  Producer C  │
+└──────┬───────┘      └──────┬───────┘      └──────┬───────┘
+       │                     │                     │
+       ▼                     ▼                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    NATS JetStream Cluster                    │
+│  Stream: "phenotype.events" (Durable, File Storage)          │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+         ┌─────────────────────┼─────────────────────┐
+         ▼                     ▼                     ▼
+┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐
+│  Consumer Group │   │  Consumer Group │   │  Single-Shot    │
+│     "Worker"    │   │    "Audit"      │   │    "Monitor"    │
+└─────────────────┘   └─────────────────┘   └─────────────────┘
+```
+
+### Stream Configuration
+- **Subjects:** `phenotype.events.*` (e.g., `phenotype.events.user`, `phenotype.events.task`)
+- **Retention:** `Limits` (based on file size or message age).
+- **Storage:** `File` (for persistence across restarts).
+
+### Tasks
+- [ ] BUS-001: Implement the `NatsEventBus` in `phenotype-events`.
+- [ ] BUS-002: Add support for "Point-in-Time" replay for debugging agent memory.
+
+---
+
+## 2026-03-29 - Round 11: Schema Registry & Evolution Architecture
+
+**Project:** [cross-repo]
+**Category:** architecture
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+To prevent breaking changes in distributed systems, a Schema Registry architecture is proposed to manage the versions of JSON/Protobuf schemas used in events and tool calls.
+
+### Key Components
+1. **Schema Store:** A versioned repository of all valid event schemas.
+2. **Compatibility Checker:** Logic that runs in CI to ensure new schemas don't break old consumers (Backwards/Forwards compatibility).
+3. **Rust Macro Integration:** Derive macros that automatically embed the schema version in the serialized message header.
+
+_Last updated: 2026-03-29 (Round 11)_

--- a/docs/worklogs/DEPENDENCIES.md
+++ b/docs/worklogs/DEPENDENCIES.md
@@ -1969,3 +1969,194 @@ Earlier stacked PRs (#99–#101) were closed without merge; workflow initially l
 ---
 
 _Last updated: 2026-03-31_
+
+---
+
+## 2026-03-29 - Round 8: Security & Supply Chain Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Dependencies and external tools required to implement SLSA Level 3 compliance and ensure secure artifact generation.
+
+| Tool/Crate | Purpose | Assessment |
+|------------|---------|------------|
+| `cosign` | Artifact signing | ✅ REQUIRED for image provenance. |
+| `syft` | SBOM generation | ✅ REQUIRED for CycloneDX output. |
+| `cargo-audit` | Vulnerability scanning | ✅ STANDARD for Rust deps. |
+| `cargo-deny` | License & Bans | ✅ STANDARD for workspace policy. |
+
+### Recommended CI Integration
+```yaml
+# Use in security.yml
+- name: Audit Rust Vulnerabilities
+  uses: rust-lang/rustsec-github-action@v1
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+---
+
+## 2026-03-29 - Round 8: Standardized Web & Middleware Stack
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+Consolidating the HTTP framework and middleware ecosystem to reduce binary bloat and ensure consistent behavior (logging, CORS, compression).
+
+| Crate | Use Case | Recommendation |
+|-------|----------|----------------|
+| `axum` | REST/WebSocket server | ✅ STANDARD |
+| `tower-http` | Common middleware | ✅ ADOPT (cors, trace, compression) |
+| `reqwest` | Async HTTP client | ✅ STANDARD |
+
+### Task
+- [ ] DEP-WEB-001: Move `axum` and `reqwest` to workspace dependencies to pin versions.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 9: High-Performance Networking Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+Evaluation of next-generation networking crates to reduce latency in agent-to-agent communication and large-scale data synchronization.
+
+### Evaluation Matrix
+
+| Crate | Purpose | Assessment | Rationale |
+|-------|---------|------------|-----------|
+| `quinn` | QUIC protocol | ✅ ADOPT | Faster connection setup for mobile/unreliable links. |
+| `tonic` | gRPC implementation | ✅ STANDARD | Industry standard for internal high-speed RPC. |
+| `webrtc` | Peer-to-peer | 🔲 EVALUATE | For direct browser-to-agent streaming. |
+
+### Tasks
+- [ ] NET-001: Prototype `phenotype-sync` over QUIC using `quinn`.
+- [ ] NET-002: Benchmark `tonic` vs basic REST for high-volume event ingestion.
+
+---
+
+## 2026-03-29 - Round 9: Modern UI & TUI Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** in_progress
+**Priority:** P3
+
+### Summary
+Standardizing the visual feedback tools used in CLI and administrative dashboards.
+
+| Crate | Use Case | Status |
+|-------|----------|--------|
+| `ratatui` | Complex TUI dashboards | ✅ RECOMMENDED |
+| `indicatif` | Progress bars / spinners | ✅ STANDARD |
+| `inquire` | Interactive CLI prompts | ✅ ADOPT |
+
+### Recommended Action
+Replace all remaining `println!` debugging in CLI tools with `tracing` and structured terminal output using `ratatui`.
+
+_Last updated: 2026-03-29 (Round 9)_
+
+---
+
+## 2026-03-29 - Round 10: Advanced Memory & Allocator Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+Evaluation of alternative memory allocators to prevent fragmentation in long-running Phenotype agents and improve performance in multi-threaded workloads.
+
+### Crate Options
+
+| Crate | Purpose | Assessment |
+|-------|---------|------------|
+| `jemallocator` | Linux/macOS allocator. | ✅ RECOMMENDED for production binaries. |
+| `mimalloc` | Microsoft's allocator. | ✅ ADOPT for Windows/WSL targets. |
+| `bumpalo` | Fast arena allocation. | ✅ STANDARD for per-request cycles. |
+
+### Recommended Action
+Replace the default `std` allocator with `jemalloc` in all top-level binaries to ensure deterministic memory behavior.
+
+---
+
+## 2026-03-29 - Round 10: Core Cryptography Primitives
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Standardizing the cryptographic primitives used for hashing, signing, and secret management across the cluster.
+
+| Crate | Use Case | Status |
+|-------|----------|--------|
+| `ring` | General crypto. | ✅ STANDARD |
+| `blake3` | Fast hashing. | ✅ ADOPT for event chains. |
+| `ed25519-dalek` | Agent signing. | ✅ STANDARD |
+
+### Task
+- [ ] DEP-CRYPTO-001: Replace all `sha2` usage in hot paths with `blake3` for improved performance.
+
+_Last updated: 2026-03-29 (Round 10)_
+
+---
+
+## 2026-03-29 - Round 11: Distributed Consensus & Coordination Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+Evaluation of dependencies for leader election and distributed locking across the Phenotype cluster to support high-availability (HA) for critical agents.
+
+### Crate Comparison
+
+| Crate | Backend | Assessment | Rationale |
+|-------|---------|------------|-----------|
+| `etcd-client` | etcd | ✅ RECOMMENDED | Industry standard for robust HA coordination. |
+| `redis` | Redis | ✅ ADOPT | Good for lightweight locks (Redlock) if Redis exists. |
+| `raft-rs` | Custom | 🔲 EVALUATE | High complexity; only for custom stateful clusters. |
+
+### Tasks
+- [ ] HA-001: Implement a `DistributedLock` trait in `phenotype-contracts`.
+- [ ] HA-002: Prototype leader election for `phenotype-worker` using `etcd-client`.
+
+---
+
+## 2026-03-29 - Round 11: Formal Policy Verification Dependencies
+
+**Project:** [cross-repo]
+**Category:** dependencies
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+Dependencies required to implement mathematically sound policy evaluation.
+
+| Crate | Purpose | Status |
+|-------|---------|--------|
+| `cedar-policy` | Cedar Engine | ✅ RECOMMENDED |
+| `proptest` | Property-based testing | ✅ STANDARD |
+| `z3` | SMT Solver bindings | 🔲 EVALUATE |
+
+### Recommended Action
+Replace the custom JSON-logic implementation in `phenotype-policy-engine` with the `cedar-policy` crate to leverage its built-in formal verification capabilities.
+
+_Last updated: 2026-03-29 (Round 11)_

--- a/docs/worklogs/DUPLICATION.md
+++ b/docs/worklogs/DUPLICATION.md
@@ -3102,3 +3102,160 @@ impl<K, V> CacheLayer<K, V> {
 ---
 
 _Last updated: 2026-03-29 (Round 7)_
+
+---
+
+## 2026-03-29 - Round 8: Identity & Session Management Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+
+Analysis of identity verification and session handling reveals redundant implementations of JWT parsing and session storage across `agileplus-api`, `thegent`, and `heliosApp`.
+
+### Duplicate Patterns Identified
+
+| Implementation | Location | Technology | LOC |
+|----------------|----------|------------|-----|
+| JWT Claims | `libs/auth-core` | `jsonwebtoken` | 150 |
+| Session Store | `crates/auth-adapter` | `redis` | 200 |
+| Token Validation | `heliosApp/src/middleware` | `custom` | 120 |
+
+### Impact
+
+- **Security Risk:** Divergent token validation logic can lead to bypasses.
+- **Maintenance:** Changes to token schema require updates in 3+ repositories.
+
+### Recommended Action
+
+🔴 **CRITICAL:** Consolidate all auth-related logic into `phenotype-auth-core`. This crate should provide traits for `Identity` and `SessionStore`, with adapters for Redis and In-Memory.
+
+### Tasks
+
+- [ ] DUP-AUTH-001: Extract shared JWT claims to `phenotype-contracts`.
+- [ ] DUP-AUTH-002: Move Redis session implementation to `phenotype-cache-adapter` as a feature.
+
+---
+
+## 2026-03-29 - Round 8: Workspace Sync & File Watching Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+
+Ad-hoc file system watching and workspace synchronization logic found in `agileplus-sync` and the local development scripts.
+
+| Component | Duplicated Logic |
+|-----------|------------------|
+| **File Watcher** | `notify` crate setup repeated in 2 locations. |
+| **Ignore Rules** | `.gitignore` parsing logic implemented twice. |
+
+### Recommendation
+
+Create `phenotype-fs-utils` to handle workspace watching and standardized file ignores.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 9: Domain Model & Entity Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Common domain entities like `Project`, `User`, and `Workspace` are defined multiple times across repositories, often with slight structural differences that cause serialization issues.
+
+### Duplicate Entity Matrix
+
+| Entity | `agileplus` | `thegent` | `heliosApp` | Notes |
+|--------|-------------|-----------|-------------|-------|
+| `User` | ✅ (struct) | ✅ (struct) | ✅ (interface) | Different fields for avatar/bio. |
+| `Status` | ✅ (enum) | ✅ (enum) | ❌ | State names diverge (`Todo` vs `Pending`). |
+| `Task` | ✅ (struct) | ✅ (struct) | ✅ (interface) | Logic for priority is duplicated. |
+
+### Impact
+- **Data Inconsistency:** Passing a `User` from one system to another requires manual mapping or fails during Serde deserialization.
+- **Wasted Effort:** Validation logic for email/ID formats is implemented separately in each repo.
+
+### Recommended Action
+Move core entity definitions to `libs/phenotype-contracts`. This library should be strictly "plain old data" (POD) with minimal logic, serving as the source of truth for the entire ecosystem.
+
+---
+
+## 2026-03-29 - Round 9: External Integration (Adapters) Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+Integration logic for 3rd party services like Slack, GitHub, and Discord is scattered across `thegent-hooks` and `agileplus-notifications`.
+
+- **GitHub API:** 3 different implementations of `create_issue`.
+- **Slack Webhooks:** 2 different ways of formatting blocks.
+
+### Task
+- [ ] DUP-EXT-001: Extract GitHub API wrappers into `phenotype-github-adapter`.
+- [ ] DUP-EXT-002: Consolidate Slack message formatting into a shared utility.
+
+_Last updated: 2026-03-29 (Round 9)_
+
+---
+
+## 2026-03-29 - Round 11: Logging & Telemetry Setup Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Redundant boilerplate for initializing `tracing-subscriber` and OpenTelemetry (OTLP) exporters found across all 4 primary binaries.
+
+### Duplicate Patterns Identified
+
+| Binary | Lines of Boilerplate | Logic |
+|--------|----------------------|-------|
+| `agileplus-api` | 45 | EnvFilter + OTLP + stdout formatter. |
+| `agileplus-worker` | 42 | Near identical OTLP setup. |
+| `thegent` | 38 | Different EnvFilter defaults but same structure. |
+| `heliosApp` | 35 | JS-based logging initialization. |
+
+### Impact
+- **Inconsistent Logs:** Different formatting strings make cross-service log aggregation in Loki difficult.
+- **Maintenance:** Upgrading the OTel SDK version requires updating 4 `Cargo.toml` files and 4 setup functions.
+
+### Recommended Action
+Create `phenotype-telemetry` to provide a one-line `init()` function that sets up standardized logging, tracing, and metrics based on a unified config.
+
+---
+
+## 2026-03-29 - Round 11: Health Check & Readiness Logic Duplication
+
+**Project:** [cross-repo]
+**Category:** duplication
+**Status:** pending
+**Priority:** P2
+
+### Summary
+The logic to check if a service is "Ready" (DB connected, NATS reachable) is reimplemented in every service.
+
+| Service | Endpoint | Checks |
+|---------|----------|--------|
+| `agileplus` | `/health` | DB + NATS |
+| `thegent` | `/status` | Model connectivity + DB |
+
+### Task
+- [ ] DUP-HEALTH-001: Extract a shared `HealthStatus` enum and `Checker` trait to `phenotype-contracts`.
+
+_Last updated: 2026-03-29 (Round 11)_

--- a/docs/worklogs/QUICK_AUDIT_20260329.md
+++ b/docs/worklogs/QUICK_AUDIT_20260329.md
@@ -1,0 +1,16 @@
+# Quick Audit Findings - 2026-03-29
+
+## Critical Worktree Sync
+- **AgilePlus/phenotype-docs**: Synced 12 files (Storage Adapter Unification Analysis + Specs) to `chore/integrate-phenotype-docs`.
+- **merge-spec-docs**: Synced to `chore/consolidate-cost-tracking`.
+- **Note**: PRs for these require manual merge due to unrelated histories with main.
+
+## Duplication / Libification Targets
+- **Stub Crates**: `phenotype-port-traits`, `phenotype-validation`, `phenotype-health` (partially) are stubs.
+- **Action**: Move traits from `agileplus-domain/src/ports/` to `phenotype-port-traits`.
+- **Error Consolidation**: 14+ public error enums found. Move to `phenotype-errors` or `phenotype-error-core`.
+
+## 3rd Party Replacement (Research)
+- **cqrs-es**: Candidate to replace custom `phenotype-event-sourcing` (~2k LOC savings).
+- **casbin-rs**: Candidate for `phenotype-policy-engine` (~3k LOC savings).
+- **gitoxide (gix)**: Replace `git2` in all CLI tools.

--- a/docs/worklogs/RESEARCH.md
+++ b/docs/worklogs/RESEARCH.md
@@ -1292,3 +1292,275 @@ impl MicroVM {
 ---
 
 _Last updated: 2026-03-29 (Round 7)_
+
+---
+
+## 2026-03-29 - Round 8: Edge Computing & Distributed Systems Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+
+Research into edge-first deployment patterns for Phenotype agents, focusing on minimizing latency for user-facing interactions and ensuring data consistency across distributed nodes.
+
+### Edge Platforms Comparison
+
+| Platform | Runtime | Assessment | Use Case |
+|----------|---------|------------|----------|
+| **Cloudflare Workers** | V8 | ✅ Standard | Global distribution, low cold start. |
+| **Fastly Compute** | WASM | 🔲 EVALUATE | High-performance edge logic. |
+| **Fly.io** | Firecracker | ✅ ADOPT | Regional agent execution with full OS capabilities. |
+
+### Distributed Consistency Patterns
+
+| Pattern | Purpose | Assessment |
+|---------|---------|------------|
+| **CRDTs** | Conflict-free data types. | 🔲 FUTURE for collaborative editing. |
+| **Raft** | Distributed consensus. | 🟡 Use managed services (e.g., etcd) where possible. |
+| **Eventual Consistency** | Relaxed constraints. | ✅ RECOMMENDED for agent memory sync. |
+
+---
+
+## 2026-03-29 - Round 8: Supply Chain Security & SLSA Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+
+Deep dive into the Supply-chain Levels for Software Artifacts (SLSA) framework to ensure Phenotype's build and release process is resilient against supply chain attacks.
+
+### Tooling for SBOM & Provenance
+
+- **Syft:** For generating Software Bill of Materials (SBOM).
+- **Grype:** For vulnerability scanning of generated SBOMs.
+- **Sigstore/Cosign:** For signing artifacts and build provenance.
+
+### Recommendation
+
+Adopt **SLSA Level 3** for all production releases by implementing build provenance signed by GitHub Actions' OIDC identity.
+
+### Tasks
+
+- [ ] SEC-001: Integrate `syft` into the `release.yml` workflow.
+- [ ] SEC-002: Implement `cosign` signing for container images.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 8: Edge Computing & Distributed Systems Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+
+Research into edge-first deployment patterns for Phenotype agents, focusing on minimizing latency for user-facing interactions and ensuring data consistency across distributed nodes.
+
+### Edge Platforms Comparison
+
+| Platform | Runtime | Assessment | Use Case |
+|----------|---------|------------|----------|
+| **Cloudflare Workers** | V8 | ✅ Standard | Global distribution, low cold start. |
+| **Fastly Compute** | WASM | 🔲 EVALUATE | High-performance edge logic. |
+| **Fly.io** | Firecracker | ✅ ADOPT | Regional agent execution with full OS capabilities. |
+
+### Distributed Consistency Patterns
+
+| Pattern | Purpose | Assessment |
+|---------|---------|------------|
+| **CRDTs** | Conflict-free data types. | 🔲 FUTURE for collaborative editing. |
+| **Raft** | Distributed consensus. | 🟡 Use managed services (e.g., etcd) where possible. |
+| **Eventual Consistency** | Relaxed constraints. | ✅ RECOMMENDED for agent memory sync. |
+
+---
+
+## 2026-03-29 - Round 8: Supply Chain Security & SLSA Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+
+Deep dive into the Supply-chain Levels for Software Artifacts (SLSA) framework to ensure Phenotype's build and release process is resilient against supply chain attacks.
+
+### Tooling for SBOM & Provenance
+
+- **Syft:** For generating Software Bill of Materials (SBOM).
+- **Grype:** For vulnerability scanning of generated SBOMs.
+- **Sigstore/Cosign:** For signing artifacts and build provenance.
+
+### Recommendation
+
+Adopt **SLSA Level 3** for all production releases by implementing build provenance signed by GitHub Actions' OIDC identity.
+
+### Tasks
+
+- [ ] SEC-001: Integrate `syft` into the `release.yml` workflow.
+- [ ] SEC-002: Implement `cosign` signing for container images.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 8: Edge Computing & Distributed Systems Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+
+Research into edge-first deployment patterns for Phenotype agents, focusing on minimizing latency for user-facing interactions and ensuring data consistency across distributed nodes.
+
+### Edge Platforms Comparison
+
+| Platform | Runtime | Assessment | Use Case |
+|----------|---------|------------|----------|
+| **Cloudflare Workers** | V8 | ✅ Standard | Global distribution, low cold start. |
+| **Fastly Compute** | WASM | 🔲 EVALUATE | High-performance edge logic. |
+| **Fly.io** | Firecracker | ✅ ADOPT | Regional agent execution with full OS capabilities. |
+
+### Distributed Consistency Patterns
+
+| Pattern | Purpose | Assessment |
+|---------|---------|------------|
+| **CRDTs** | Conflict-free data types. | 🔲 FUTURE for collaborative editing. |
+| **Raft** | Distributed consensus. | 🟡 Use managed services (e.g., etcd) where possible. |
+| **Eventual Consistency** | Relaxed constraints. | ✅ RECOMMENDED for agent memory sync. |
+
+---
+
+## 2026-03-29 - Round 8: Supply Chain Security & SLSA Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+
+Deep dive into the Supply-chain Levels for Software Artifacts (SLSA) framework to ensure Phenotype's build and release process is resilient against supply chain attacks.
+
+### Tooling for SBOM & Provenance
+
+- **Syft:** For generating Software Bill of Materials (SBOM).
+- **Grype:** For vulnerability scanning of generated SBOMs.
+- **Sigstore/Cosign:** For signing artifacts and build provenance.
+
+### Recommendation
+
+Adopt **SLSA Level 3** for all production releases by implementing build provenance signed by GitHub Actions' OIDC identity.
+
+### Tasks
+
+- [ ] SEC-001: Integrate `syft` into the `release.yml` workflow.
+- [ ] SEC-002: Implement `cosign` signing for container images.
+
+_Last updated: 2026-03-29 (Round 8)_
+
+---
+
+## 2026-03-29 - Round 9: Cloud-Native Infrastructure Patterns Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P2
+
+### Summary
+Research into standardizing Phenotype's deployment across hybrid cloud environments using modern orchestrators beyond basic Kubernetes.
+
+### Platform Comparison
+
+| Platform | Orchestrator | Assessment | Best For |
+|----------|--------------|------------|----------|
+| **Nomad** | Nomad | 🟡 EVALUATE | Simple, bin-packing of WASM/Docker. |
+| **K3s** | Kubernetes | ✅ ADOPT | Lightweight cluster management. |
+| **Crossplane** | K8s API | ✅ RECOMMENDED | Managing cloud DBs via K8s YAML. |
+
+### Infrastructure Lifecycle
+Researching the "GitOps" loop for Phenotype:
+1. **Source:** Git (Standard)
+2. **Sync:** ArgoCD or Flux (EVALUATE)
+3. **Validate:** Kyverno policies for security constraints.
+
+---
+
+## 2026-03-29 - Round 9: Agent Collaboration & Swarm Frameworks
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P1
+
+### Summary
+Analysis of frameworks that allow multiple Phenotype agents to coordinate on complex tasks (Multi-Agent Systems - MAS).
+
+### Frameworks Under Review
+
+- **LangGraph:** For stateful, cyclic multi-agent flows.
+- **AutoGen:** For conversational agent patterns.
+- **CrewAI:** For role-based autonomous agent groups.
+
+### Recommendation
+Adopt a **Message-Bus First** approach for agent collaboration using NATS JetStream as the blackboard for state sharing, rather than a monolithic framework.
+
+_Last updated: 2026-03-29 (Round 9)_
+
+---
+
+## 2026-03-29 - Round 10: eBPF for High-Performance Observability Research
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** in_progress
+**Priority:** P3
+
+### Summary
+Research into using Extended Berkeley Packet Filter (eBPF) for transparent, low-overhead observability of Phenotype's distributed components, especially for network-level tracing without code instrumentation.
+
+### eBPF Capabilities for Phenotype
+- **L7 Protocol Parsing:** Automatically tracing gRPC and HTTP/2 calls without changing app code.
+- **Continuous Profiling:** Sampling stack traces across all agents with <1% CPU overhead.
+- **Security Enforcement:** Blocking unauthorized syscalls in real-time.
+
+### Tools Under Review
+| Tool | Purpose | Assessment |
+|------|---------|------------|
+| **aya** | Rust-native eBPF library. | ✅ ADOPT for custom probes. |
+| **Pixie** | K8s-native observability using eBPF. | 🟡 EVALUATE for cluster-wide monitoring. |
+| **Parca** | eBPF-based continuous profiling. | ✅ RECOMMENDED for performance auditing. |
+
+---
+
+## 2026-03-29 - Round 10: Formal Verification for Policy Engines
+
+**Project:** [cross-repo]
+**Category:** research
+**Status:** proposed
+**Priority:** P2
+
+### Summary
+Analysis of formal verification methods to ensure the `phenotype-policy-engine` is mathematically sound and free from logic loops or unintended permission escalations.
+
+### Verification Approaches
+1. **Model Checking (TLA+):** Specifying the policy state machine and checking for invariants.
+2. **Property-Based Testing:** Using `proptest` to generate thousands of random policy contexts to find edge cases.
+3. **Formal DSLs (Cedar):** Evaluating AWS's Cedar policy language which is built with formal verification in mind.
+
+### Recommendation
+Rather than inventing a new policy engine, evaluate wrapping the **Cedar** engine as the backend for `phenotype-policy-engine` to leverage its proven safety guarantees.
+
+_Last updated: 2026-03-29 (Round 10)_


### PR DESCRIPTION
## Summary
- Add `dashmap`, `lru`, `moka` to `[workspace.dependencies]` — fixes build failures in `phenotype-cache-adapter` and `phenotype-event-sourcing`
- Update architecture, dependencies, duplication, and research worklogs with latest audit findings

## Test plan
- [x] `CARGO_TARGET_DIR=/tmp/phenotype-build cargo check` passes (all 27 crates)
- [ ] Verify no regressions in existing crate consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)