### PR TITLE
feat(phenotype-http-client-core): rewrite and add to workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,3 @@ docs/worklogs/libification/WS6_RUST_TOML_AUDIT.md
 service_fixed.py
 service_working.py
 crates/phenotype-contracts/tests/
-crates/phenotype-http-client-core/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/phenotype-logging",
     "crates/phenotype-macros",
     "crates/phenotype-mcp",
+    "crates/phenotype-http-client-core",
 ]
 
 [workspace.package]

--- a/crates/phenotype-http-client-core/Cargo.toml
+++ b/crates/phenotype-http-client-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "phenotype-http-client-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HTTP client core traits and retry logic for Phenotype"
+
+[dependencies]
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+async-trait.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/phenotype-http-client-core/src/auth.rs
+++ b/crates/phenotype-http-client-core/src/auth.rs
@@ -1,132 +1,88 @@
-//! HTTP authentication middleware.
-
-use http::{Request, Response, header::HeaderName, header::HeaderValue};
-use std::sync::Arc;
+//! HTTP authentication helpers.
 
 /// Authentication credentials.
 #[derive(Debug, Clone)]
 pub enum AuthCredentials {
-    /// Bearer token authentication.
     Bearer(String),
-    /// API key authentication.
-    ApiKey {
-        key: String,
-        value: String,
-        location: ApiKeyLocation,
-    },
-    /// Basic authentication.
+    ApiKey { header: String, value: String },
     Basic { username: String, password: String },
 }
 
-/// Where to place the API key.
-#[derive(Debug, Clone, Copy)]
-pub enum ApiKeyLocation {
-    /// In the Authorization header.
-    Authorization,
-    /// In a custom header.
-    Header(HeaderName),
-    /// As a query parameter.
-    QueryParam(String),
-}
-
 impl AuthCredentials {
-    /// Create bearer token credentials.
     pub fn bearer(token: impl Into<String>) -> Self {
         Self::Bearer(token.into())
     }
 
-    /// Create API key credentials.
-    pub fn api_key(key: impl Into<String>, value: impl Into<String>, location: ApiKeyLocation) -> Self {
+    pub fn api_key(header: impl Into<String>, value: impl Into<String>) -> Self {
         Self::ApiKey {
-            key: key.into(),
+            header: header.into(),
             value: value.into(),
-            location,
         }
     }
 
-    /// Create basic auth credentials.
     pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
         Self::Basic {
             username: username.into(),
             password: password.into(),
         }
     }
+
+    /// Return the header name and value for this credential.
+    pub fn to_header(&self) -> (String, String) {
+        match self {
+            Self::Bearer(token) => ("Authorization".to_string(), format!("Bearer {token}")),
+            Self::ApiKey { header, value } => (header.clone(), value.clone()),
+            Self::Basic { username, password } => {
+                use std::io::Write;
+                let mut buf = Vec::new();
+                write!(buf, "{username}:{password}").unwrap();
+                let encoded = base64_encode(&buf);
+                ("Authorization".to_string(), format!("Basic {encoded}"))
+            }
+        }
+    }
 }
 
-/// Authentication middleware.
+/// Auth middleware that holds credentials.
 #[derive(Debug, Clone)]
 pub struct AuthMiddleware {
-    credentials: Arc<AuthCredentials>,
+    credentials: AuthCredentials,
 }
 
 impl AuthMiddleware {
-    /// Create new auth middleware.
     pub fn new(credentials: AuthCredentials) -> Self {
-        Self {
-            credentials: Arc::new(credentials),
-        }
+        Self { credentials }
     }
 
-    /// Apply authentication to a request.
-    pub fn apply<B>(&self, mut request: Request<B>) -> Result<Response<Vec<u8>>, crate::error::TransportError> {
-        match self.credentials.as_ref() {
-            AuthCredentials::Bearer(token) => {
-                let header_value = HeaderValue::from_str(&format!("Bearer {}", token))
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid bearer token: {}", e)))?;
-                request.headers_mut().insert(header::AUTHORIZATION, header_value);
-            }
-            AuthCredentials::ApiKey { key, value, location } => {
-                let header_name = match location {
-                    ApiKeyLocation::Authorization => header::AUTHORIZATION,
-                    ApiKeyLocation::Header(name) => *name,
-                    ApiKeyLocation::QueryParam(_) => {
-                        return Err(crate::error::TransportError::Auth(
-                            "Query param auth not supported in middleware".into(),
-                        ));
-                    }
-                };
-
-                let header_value = HeaderValue::from_str(&value)
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid API key: {}", e)))?;
-                request.headers_mut().insert(header_name, header_value);
-            }
-            AuthCredentials::Basic { username, password } => {
-                let credentials = base64::Engine::encode(
-                    &base64::engine::general_purpose::STANDARD,
-                    format!("{}:{}", username, password),
-                );
-                let header_value = HeaderValue::from_str(&format!("Basic {}", credentials))
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid basic auth: {}", e)))?;
-                request.headers_mut().insert(header::AUTHORIZATION, header_value);
-            }
-        }
-
-        Ok(Response::new(Vec::new()))
+    /// Get the auth header pair.
+    pub fn header(&self) -> (String, String) {
+        self.credentials.to_header()
     }
 }
 
-/// Convenience extension trait for adding auth to requests.
-pub trait RequestAuthExt {
-    /// Add bearer authentication.
-    fn bearer_auth(self, token: impl Into<String>) -> Self;
-
-    /// Add API key authentication.
-    fn api_key_auth(self, key: impl Into<String>, value: impl Into<String>) -> Self;
-}
-
-impl<B> RequestAuthExt for Request<B> {
-    fn bearer_auth(mut self, token: impl Into<String>) -> Self {
-        let header_value = HeaderValue::from_str(&format!("Bearer {}", token.into())).unwrap();
-        self.headers_mut().insert(header::AUTHORIZATION, header_value);
-        self
+/// Simple base64 encoding (no external dep).
+fn base64_encode(input: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::new();
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
     }
-
-    fn api_key_auth(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        let header_name = HeaderName::from_bytes(key.into().as_bytes()).unwrap();
-        let header_value = HeaderValue::from_str(&value.into()).unwrap();
-        self.headers_mut().insert(header_name, header_value);
-        self
-    }
+    result
 }
 
 #[cfg(test)]
@@ -134,24 +90,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bearer_auth() {
-        let creds = AuthCredentials::bearer("my-token");
-        match creds {
-            AuthCredentials::Bearer(token) => assert_eq!(token, "my-token"),
-            _ => panic!("Expected Bearer variant"),
-        }
+    fn bearer_header() {
+        let creds = AuthCredentials::bearer("tok123");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "Authorization");
+        assert_eq!(value, "Bearer tok123");
     }
 
     #[test]
-    fn test_api_key_auth() {
-        let creds = AuthCredentials::api_key("X-API-Key", "secret-key", ApiKeyLocation::Authorization);
-        match creds {
-            AuthCredentials::ApiKey { key, value, location } => {
-                assert_eq!(key, "X-API-Key");
-                assert_eq!(value, "secret-key");
-                matches!(location, ApiKeyLocation::Authorization);
-            }
-            _ => panic!("Expected ApiKey variant"),
-        }
+    fn api_key_header() {
+        let creds = AuthCredentials::api_key("X-API-Key", "secret");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "X-API-Key");
+        assert_eq!(value, "secret");
+    }
+
+    #[test]
+    fn basic_header() {
+        let creds = AuthCredentials::basic("user", "pass");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "Authorization");
+        assert!(value.starts_with("Basic "));
+    }
+
+    #[test]
+    fn base64_encode_hello() {
+        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
     }
 }

--- a/crates/phenotype-http-client-core/src/error.rs
+++ b/crates/phenotype-http-client-core/src/error.rs
@@ -23,20 +23,8 @@ pub enum TransportError {
     #[error("server error: {status} - {message}")]
     Server { status: u16, message: String },
 
-    #[error("parse error: {0}")]
-    Parse(String),
-
-    #[error("validation error: {0}")]
-    Validation(String),
-
     #[error("not found: {0}")]
     NotFound(String),
-
-    #[error("forbidden: {0}")]
-    Forbidden(String),
-
-    #[error("conflict: {0}")]
-    Conflict(String),
 
     #[error("serialization error: {0}")]
     Serialization(String),
@@ -46,15 +34,6 @@ pub enum TransportError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-
-    #[error("http error: {0}")]
-    Http(#[from] http::Error),
-
-    #[error("url error: {0}")]
-    Url(#[from] url::ParseError),
-
-    #[error("reqwest error: {0}")]
-    Reqwest(#[from] reqwest::Error),
 }
 
 impl TransportError {
@@ -78,22 +57,15 @@ impl TransportError {
             TransportError::Authentication(_) => ErrorKind::Authentication,
             TransportError::RateLimited { .. } => ErrorKind::RateLimited,
             TransportError::Server { .. } => ErrorKind::Server,
-            TransportError::Parse(_) => ErrorKind::Parse,
-            TransportError::Validation(_) => ErrorKind::Validation,
             TransportError::NotFound(_) => ErrorKind::NotFound,
-            TransportError::Forbidden(_) => ErrorKind::Forbidden,
-            TransportError::Conflict(_) => ErrorKind::Conflict,
             TransportError::Serialization(_) => ErrorKind::Serialization,
             TransportError::Unknown(_) => ErrorKind::Unknown,
             TransportError::Io(_) => ErrorKind::Io,
-            TransportError::Http(_) => ErrorKind::Http,
-            TransportError::Url(_) => ErrorKind::Url,
-            TransportError::Reqwest(_) => ErrorKind::Reqwest,
         }
     }
 }
 
-/// Error kind categorization for transport errors.
+/// Error kind categorization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorKind {
     Request,
@@ -102,15 +74,8 @@ pub enum ErrorKind {
     Authentication,
     RateLimited,
     Server,
-    Parse,
-    Validation,
     NotFound,
-    Forbidden,
-    Conflict,
     Serialization,
     Unknown,
     Io,
-    Http,
-    Url,
-    Reqwest,
 }

--- a/crates/phenotype-http-client-core/src/lib.rs
+++ b/crates/phenotype-http-client-core/src/lib.rs
@@ -1,129 +1,45 @@
 //! # HTTP Client Core
 //!
-//! Core traits and utilities for HTTP clients in the Phenotype ecosystem.
-//!
-//! ## Features
-//!
-//! - `HttpTransport` - Core transport trait for HTTP clients
-//! - `RetryPolicy` - Retry logic with backoff
-//! - `TransportError` - Unified error types
-//! - `AuthMiddleware` - Authentication middleware support
-//!
-//! ## Usage
-//!
-//! ```rust,ignore
-//! use phenotype_http_client_core::{HttpTransport, RetryPolicy, TransportError};
-//!
-//! struct MyClient {
-//!     base_url: url::Url,
-//!     inner: reqwest::Client,
-//! }
-//!
-//! #[async_trait::async_trait]
-//! impl HttpTransport for MyClient {
-//!     async fn request(&self, req: http::Request<Vec<u8>>) -> Result<http::Response<Vec<u8>>, TransportError> {
-//!         // implementation
-//!     }
-//! }
-//! ```
+//! Core traits and retry logic for HTTP clients in the Phenotype ecosystem.
+//! Minimal, no external HTTP crate dependency — consumers bring their own (reqwest, hyper, etc).
 
+pub mod auth;
 pub mod error;
 pub mod retry;
-pub mod transport;
-pub mod auth;
 
-pub use error::{TransportError, ErrorKind};
-pub use retry::{RetryPolicy, Backoff};
-pub use transport::HttpTransport;
-pub use auth::{AuthMiddleware, BearerToken};
-
-use thiserror::Error;
+pub use auth::{AuthCredentials, AuthMiddleware};
+pub use error::{ErrorKind, TransportError};
+pub use retry::RetryPolicy;
 
 /// Result type for HTTP transport operations.
 pub type Result<T> = std::result::Result<T, TransportError>;
 
-/// Extension trait for adding retry logic to transports.
-pub trait RetryExt: HttpTransport {
-    /// Wrap this transport with retry logic.
-    fn with_retry(self, policy: RetryPolicy) -> RetryTransport<Self>
-    where
-        Self: Sized,
-    {
-        RetryTransport {
-            inner: self,
-            policy,
-        }
-    }
-
-    /// Wrap this transport with authentication.
-    fn with_auth(self, auth: AuthMiddleware) -> AuthTransport<Self>
-    where
-        Self: Sized,
-    {
-        AuthTransport {
-            inner: self,
-            auth,
-        }
-    }
-}
-
-impl<T: HttpTransport> RetryExt for T {}
-
-/// Transport wrapper that adds retry logic.
-#[derive(Debug, Clone)]
-pub struct RetryTransport<T> {
-    inner: T,
-    policy: RetryPolicy,
-}
-
+/// Core HTTP transport trait. Implementors wrap their preferred HTTP client.
 #[async_trait::async_trait]
-impl<T: HttpTransport> HttpTransport for RetryTransport<T> {
-    async fn request(
+pub trait HttpTransport: Send + Sync {
+    async fn execute(
         &self,
-        req: http::Request<Vec<u8>>,
-    ) -> Result<http::Response<Vec<u8>>> {
-        let mut attempt = 0;
-        let mut last_error = None;
-
-        loop {
-            match self.inner.request(req.clone()).await {
-                Ok(response) => return Ok(response),
-                Err(e) => {
-                    attempt += 1;
-                    last_error = Some(e);
-
-                    if attempt >= self.policy.max_attempts {
-                        break;
-                    }
-
-                    if !self.policy.should_retry(&e) {
-                        break;
-                    }
-
-                    let delay = self.policy.backoff.calculate(attempt);
-                    tokio::time::sleep(delay).await;
-                }
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| TransportError::Unknown("No error".into())))
-    }
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: Option<&[u8]>,
+    ) -> Result<HttpResponse>;
 }
 
-/// Transport wrapper that adds authentication.
+/// Simplified HTTP response.
 #[derive(Debug, Clone)]
-pub struct AuthTransport<T> {
-    inner: T,
-    auth: AuthMiddleware,
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
 }
 
-#[async_trait::async_trait]
-impl<T: HttpTransport> HttpTransport for AuthTransport<T> {
-    async fn request(
-        &self,
-        mut req: http::Request<Vec<u8>>,
-    ) -> Result<http::Response<Vec<u8>>> {
-        self.auth.apply(&mut req);
-        self.inner.request(req).await
+impl HttpResponse {
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    pub fn body_as_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.body)
     }
 }

--- a/crates/phenotype-http-client-core/src/retry.rs
+++ b/crates/phenotype-http-client-core/src/retry.rs
@@ -1,86 +1,45 @@
 //! HTTP retry policy with exponential backoff.
 
-use std::time::Duration;
 use crate::error::TransportError;
+use std::time::Duration;
 
 /// Retry policy configuration.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
-    /// Maximum number of retries.
-    pub max_retries: u32,
-    /// Initial delay between retries.
+    pub max_attempts: u32,
     pub initial_delay: Duration,
-    /// Maximum delay between retries.
     pub max_delay: Duration,
-    /// Multiplier for exponential backoff.
     pub backoff_multiplier: f64,
-    /// Jitter factor (0.0 to 1.0).
-    pub jitter: f64,
 }
 
 impl Default for RetryPolicy {
     fn default() -> Self {
         Self {
-            max_retries: 3,
+            max_attempts: 3,
             initial_delay: Duration::from_millis(100),
             max_delay: Duration::from_secs(30),
             backoff_multiplier: 2.0,
-            jitter: 0.1,
         }
     }
 }
 
 impl RetryPolicy {
-    /// Create a new retry policy with custom configuration.
-    pub fn new(
-        max_retries: u32,
-        initial_delay: Duration,
-        max_delay: Duration,
-        backoff_multiplier: f64,
-        jitter: f64,
-    ) -> Self {
-        Self {
-            max_retries,
-            initial_delay,
-            max_delay,
-            backoff_multiplier,
-            jitter,
-        }
-    }
-
-    /// Calculate the delay for the given attempt number.
+    /// Calculate the delay for the given attempt number (0-indexed).
     pub fn delay_for(&self, attempt: u32) -> Duration {
-        let base_delay = self.initial_delay * self.backoff_multiplier.powi(attempt as i32 - 1);
-        let capped_delay = base_delay.min(self.max_delay);
-
-        // Add jitter
-        let jitter_range = capped_delay.mul_f64(self.jitter);
-        let jitter_ns = (rand_ratio() * jitter_range.as_nanos() as f64) as u64;
-
-        capped_delay + Duration::from_nanos(jitter_ns)
+        let base = self.initial_delay.mul_f64(self.backoff_multiplier.powi(attempt as i32));
+        base.min(self.max_delay)
     }
 
-    /// Check if we should retry the given error.
+    /// Check if we should retry the given error at the given attempt.
     pub fn should_retry(&self, error: &TransportError, attempt: u32) -> bool {
-        if attempt >= self.max_retries {
+        if attempt >= self.max_attempts {
             return false;
         }
-
         error.is_retryable()
     }
 }
 
-/// Simple pseudo-random number generator for jitter.
-fn rand_ratio() -> f64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .subsec_nanos();
-    (nanos % 1000) as f64 / 1000.0
-}
-
-/// Retry future with policy.
+/// Execute a closure with retry logic.
 pub async fn retry_with_policy<F, Fut, T>(
     policy: &RetryPolicy,
     mut f: F,
@@ -90,7 +49,6 @@ where
     Fut: std::future::Future<Output = Result<T, TransportError>>,
 {
     let mut attempt = 0u32;
-
     loop {
         match f().await {
             Ok(result) => return Ok(result),
@@ -98,9 +56,8 @@ where
                 if !policy.should_retry(&error, attempt) {
                     return Err(error);
                 }
-
                 let delay = policy.delay_for(attempt);
-                tracing::debug!("retry attempt {} after {:?}: {}", attempt, delay, error);
+                tracing::debug!(attempt, ?delay, %error, "retrying request");
                 tokio::time::sleep(delay).await;
                 attempt += 1;
             }
@@ -113,43 +70,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_retry_policy_default() {
+    fn default_policy() {
         let policy = RetryPolicy::default();
-        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.max_attempts, 3);
     }
 
     #[test]
-    fn test_delay_calculation() {
-        let policy = RetryPolicy::new(3, Duration::from_millis(100), Duration::from_secs(30), 2.0, 0.0);
-
-        // Attempt 0: 100ms
-        let delay0 = policy.delay_for(0);
-        assert_eq!(delay0, Duration::from_millis(100));
-
-        // Attempt 1: 200ms
-        let delay1 = policy.delay_for(1);
-        assert_eq!(delay1, Duration::from_millis(200));
-
-        // Attempt 2: 400ms
-        let delay2 = policy.delay_for(2);
-        assert_eq!(delay2, Duration::from_millis(400));
+    fn delay_calculation() {
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(30),
+            backoff_multiplier: 2.0,
+        };
+        assert_eq!(policy.delay_for(0), Duration::from_millis(100));
+        assert_eq!(policy.delay_for(1), Duration::from_millis(200));
+        assert_eq!(policy.delay_for(2), Duration::from_millis(400));
     }
 
     #[test]
-    fn test_should_retry() {
+    fn should_retry_retryable() {
         let policy = RetryPolicy::default();
+        let err = TransportError::Timeout("timeout".into());
+        assert!(policy.should_retry(&err, 0));
+        assert!(!policy.should_retry(&err, 3));
+    }
 
-        // Timeout is retryable
-        let timeout = TransportError::Timeout("timeout".into());
-        assert!(policy.should_retry(&timeout, 0));
-        assert!(policy.should_retry(&timeout, 1));
-        assert!(policy.should_retry(&timeout, 2));
-
-        // But not after max retries
-        assert!(!policy.should_retry(&timeout, 3));
-
-        // Validation error is not retryable
-        let validation = TransportError::Validation("invalid".into());
-        assert!(!policy.should_retry(&validation, 0));
+    #[test]
+    fn should_not_retry_non_retryable() {
+        let policy = RetryPolicy::default();
+        let err = TransportError::NotFound("missing".into());
+        assert!(!policy.should_retry(&err, 0));
     }
 }


### PR DESCRIPTION
## Summary
- Complete rewrite of partially broken `phenotype-http-client-core` crate
- `HttpTransport` trait — bring-your-own HTTP client, no reqwest/hyper dependency
- `TransportError` with `is_retryable()` detection
- `RetryPolicy` with exponential backoff and `retry_with_policy()` helper
- `AuthMiddleware` with Bearer, API key, Basic auth (zero external deps, inline base64)
- Add to workspace members (was orphaned outside workspace)
- Un-ignore from `.gitignore`
- **29 crates in workspace, zero errors, zero warnings, 8 new tests**

## Test plan
- [x] `cargo test -p phenotype-http-client-core` — 8/8 pass
- [x] `cargo check` — full workspace clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)