### PR TITLE
fix: resolve all clippy warnings and fix telemetry modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,3 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
-
-# blake3 dependency
-generic-array = "0.14"

--- a/crates/phenotype-logging/src/lib.rs
+++ b/crates/phenotype-logging/src/lib.rs
@@ -19,8 +19,10 @@ pub use tracing::{span, Level, Span};
 /// Log output format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum LogFormat {
     /// Human-readable, multi-line output (default for development).
+    #[default]
     Pretty,
     /// Single-line human-readable output.
     Compact,
@@ -28,11 +30,6 @@ pub enum LogFormat {
     Json,
 }
 
-impl Default for LogFormat {
-    fn default() -> Self {
-        Self::Pretty
-    }
-}
 
 /// Configuration for the logging subsystem.
 ///

--- a/crates/phenotype-macros/src/aggregate.rs
+++ b/crates/phenotype-macros/src/aggregate.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident; let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig Aggregate for #name #tg #wc {} impl #ig #name #tg #wc { pub fn aggregate_name() -> &'static str { stringify!(#name) } } }.into()
+    quote! { impl #ig Aggregate for #name #tg #wc {} impl #ig #name #tg #wc { pub fn aggregate_name() -> &'static str { stringify!(#name) } } }
 }

--- a/crates/phenotype-macros/src/command.rs
+++ b/crates/phenotype-macros/src/command.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident; let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig Command for #name #tg #wc {} impl #ig #name #tg #wc { pub fn command_name() -> &'static str { stringify!(#name) } } }.into()
+    quote! { impl #ig Command for #name #tg #wc {} impl #ig #name #tg #wc { pub fn command_name() -> &'static str { stringify!(#name) } } }
 }

--- a/crates/phenotype-macros/src/entity.rs
+++ b/crates/phenotype-macros/src/entity.rs
@@ -2,5 +2,5 @@ use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident;
     let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig Entity for #name #tg #wc {} impl #ig #name #tg #wc { pub fn entity_name() -> &'static str { stringify!(#name) } } }.into()
+    quote! { impl #ig Entity for #name #tg #wc {} impl #ig #name #tg #wc { pub fn entity_name() -> &'static str { stringify!(#name) } } }
 }

--- a/crates/phenotype-macros/src/error.rs
+++ b/crates/phenotype-macros/src/error.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident; let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig std::fmt::Debug for #name #tg #wc { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { std::fmt::Display::fmt(self, f) } } impl #ig std::error::Error for #name #tg #wc {} }.into()
+    quote! { impl #ig std::fmt::Debug for #name #tg #wc { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { std::fmt::Display::fmt(self, f) } } impl #ig std::error::Error for #name #tg #wc {} }
 }

--- a/crates/phenotype-macros/src/event.rs
+++ b/crates/phenotype-macros/src/event.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident; let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig DomainEvent for #name #tg #wc {} impl #ig #name #tg #wc { pub fn event_type() -> &'static str { stringify!(#name) } } }.into()
+    quote! { impl #ig DomainEvent for #name #tg #wc {} impl #ig #name #tg #wc { pub fn event_type() -> &'static str { stringify!(#name) } } }
 }

--- a/crates/phenotype-macros/src/value_object.rs
+++ b/crates/phenotype-macros/src/value_object.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream; use quote::quote; use syn::DeriveInput;
 pub fn derive(input: DeriveInput) -> TokenStream {
     let name = &input.ident; let (ig, tg, wc) = input.generics.split_for_impl();
-    quote! { impl #ig ValueObject for #name #tg #wc {} impl #ig std::cmp::PartialEq for #name #tg #wc { fn eq(&self, o: &Self) -> bool { self.0 == o.0 } } impl #ig std::cmp::Eq for #name #tg #wc {} impl #ig std::hash::Hash for #name #tg #wc { fn hash<H: std::hash::Hasher>(&self, s: &mut H) { self.0.hash(s); } } }.into()
+    quote! { impl #ig ValueObject for #name #tg #wc {} impl #ig std::cmp::PartialEq for #name #tg #wc { fn eq(&self, o: &Self) -> bool { self.0 == o.0 } } impl #ig std::cmp::Eq for #name #tg #wc {} impl #ig std::hash::Hash for #name #tg #wc { fn hash<H: std::hash::Hasher>(&self, s: &mut H) { self.0.hash(s); } } }
 }

--- a/crates/phenotype-string/src/lib.rs
+++ b/crates/phenotype-string/src/lib.rs
@@ -44,7 +44,7 @@ pub fn to_snake_case(s: &str) -> String {
 
 /// Convert a string to PascalCase.
 pub fn to_pascal_case(s: &str) -> String {
-    s.split(|c: char| c == '_' || c == '-' || c == ' ')
+    s.split(['_', '-', ' '])
         .filter(|w| !w.is_empty())
         .map(|w| {
             let mut chars = w.chars();

--- a/crates/phenotype-telemetry/src/lib.rs
+++ b/crates/phenotype-telemetry/src/lib.rs
@@ -1,25 +1,6 @@
-//! Canonical telemetry (metrics collection) for Phenotype services.
-//!
-//! Provides [`MetricsRegistry`] for registering and updating counters, gauges,
-//! and histograms, plus [`SpanTimer`] for Drop-based duration measurement and
-//! [`MetricsSnapshot`] for point-in-time JSON-serializable reporting.
+//! Phenotype Telemetry — metrics and tracing utilities.
 
-mod registry;
-mod snapshot;
-mod timer;
+pub mod metrics;
+pub mod tracing;
 
-pub use registry::{Counter, Gauge, Histogram, Metric, MetricsRegistry, TelemetryConfig};
-pub use snapshot::MetricsSnapshot;
-pub use timer::{timed, SpanTimer};
-
-/// Initialise a [`MetricsRegistry`] from the given configuration.
-///
-/// This is the primary entry point for setting up telemetry in a service.
-pub fn init_telemetry(config: TelemetryConfig) -> MetricsRegistry {
-    tracing::info!(
-        service = %config.service_name,
-        env = %config.environment,
-        "initialising telemetry"
-    );
-    MetricsRegistry::new(config)
-}
+pub use metrics::Counter;

--- a/crates/phenotype-telemetry/src/metrics.rs
+++ b/crates/phenotype-telemetry/src/metrics.rs
@@ -8,6 +8,12 @@ pub struct Counter {
     value: Arc<AtomicU64>,
 }
 
+impl Default for Counter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Counter {
     pub fn new() -> Self {
         Self { value: Arc::new(AtomicU64::new(0)) }

--- a/crates/phenotype-time/src/lib.rs
+++ b/crates/phenotype-time/src/lib.rs
@@ -81,7 +81,9 @@ impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let t = self.0.as_secs(); let h = t/3600; let m = (t%3600)/60; let s = t%60;
         let mut p = Vec::new();
-        if h > 0 { p.push(format!("{h}h")); } if m > 0 { p.push(format!("{m}m")); } if s > 0 || p.is_empty() { p.push(format!("{s}s")); }
+        if h > 0 { p.push(format!("{h}h")); }
+        if m > 0 { p.push(format!("{m}m")); }
+        if s > 0 || p.is_empty() { p.push(format!("{s}s")); }
         write!(f, "{}", p.join(" "))
     }
 }


### PR DESCRIPTION
## Summary
- Zero clippy warnings across entire workspace (was 10+)
- Fix telemetry lib.rs to match existing source files
- Remove useless .into() in macros, derive Default in logging
- Fix formatting in phenotype-time, phenotype-string
- Remove stray generic-array manifest key

## Test plan
- [x] `cargo clippy --workspace` — 0 warnings
- [x] `cargo test --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)