### PR TITLE
fix(macros): upgrade thiserror to v2.0 (workspace version)

### DIFF
--- a/crates/phenotype-macros/Cargo.toml
+++ b/crates/phenotype-macros/Cargo.toml
@@ -13,4 +13,4 @@ syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 serde = { version = "1", features = ["derive"] }
-thiserror = "1"
+thiserror.workspace = true


### PR DESCRIPTION
Resolves version mismatch where phenotype-macros was using thiserror v1.0 while the workspace declared v2.0.

This change:
- Updates phenotype-macros/Cargo.toml to use workspace version
- Aligns with workspace dependencies (thiserror = 2.0)
- Verified with cargo check (no compilation errors)

## Verification
```
CARGO_TARGET_DIR=/tmp/macros-build cargo check -p phenotype-macros
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.53s
```