### PR TITLE
test: add comprehensive tests across low-coverage crates

### DIFF
--- a/crates/agileplus-api-types/Cargo.toml
+++ b/crates/agileplus-api-types/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/agileplus-api-types/src/lib.rs
+++ b/crates/agileplus-api-types/src/lib.rs
@@ -15,4 +15,68 @@ impl<T> ApiResponse<T> {
             error: None,
         }
     }
+
+    pub fn error(msg: impl Into<String>) -> Self {
+        Self {
+            data: None,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn success_response_has_data_no_error() {
+        let resp = ApiResponse::success(42);
+        assert_eq!(resp.data, Some(42));
+        assert!(resp.error.is_none());
+    }
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn error_response_has_error_no_data() {
+        let resp = ApiResponse::<i32>::error("not found");
+        assert!(resp.data.is_none());
+        assert_eq!(resp.error.as_deref(), Some("not found"));
+    }
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn response_debug_impl() {
+        let resp = ApiResponse::success("hello");
+        let dbg = format!("{:?}", resp);
+        assert!(dbg.contains("hello"));
+    }
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn response_clone() {
+        let resp = ApiResponse::success(vec![1, 2, 3]);
+        let cloned = resp.clone();
+        assert_eq!(cloned.data, Some(vec![1, 2, 3]));
+    }
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn response_serialization_roundtrip() {
+        let resp = ApiResponse::success("test".to_string());
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: ApiResponse<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.data, Some("test".to_string()));
+        assert!(deserialized.error.is_none());
+    }
+
+    // Traces to: FR-AGILE-001
+    #[test]
+    fn error_response_serialization_roundtrip() {
+        let resp = ApiResponse::<String>::error("fail");
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: ApiResponse<String> = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.data.is_none());
+        assert_eq!(deserialized.error.as_deref(), Some("fail"));
+    }
 }

--- a/crates/phenotype-errors/src/lib.rs
+++ b/crates/phenotype-errors/src/lib.rs
@@ -23,3 +23,72 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_display_failed() {
+        let e = Error::Failed("disk full".into());
+        assert_eq!(e.to_string(), "Operation failed: disk full");
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_display_not_found() {
+        let e = Error::NotFound("user/42".into());
+        assert_eq!(e.to_string(), "Not found: user/42");
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_display_timeout() {
+        let e = Error::Timeout("5s elapsed".into());
+        assert_eq!(e.to_string(), "Timeout: 5s elapsed");
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_display_unauthorized() {
+        let e = Error::Unauthorized("bad token".into());
+        assert_eq!(e.to_string(), "Unauthorized: bad token");
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_display_internal() {
+        let e = Error::Internal("segfault".into());
+        assert_eq!(e.to_string(), "Internal error: segfault");
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_is_std_error() {
+        let e: Box<dyn std::error::Error> = Box::new(Error::Failed("x".into()));
+        assert!(e.to_string().contains("Operation failed"));
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn result_type_ok() {
+        let r: Result<i32> = Ok(42);
+        assert_eq!(r.unwrap(), 42);
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn result_type_err() {
+        let r: Result<i32> = Err(Error::NotFound("missing".into()));
+        assert!(r.is_err());
+    }
+
+    // Traces to: FR-PHENO-001
+    #[test]
+    fn error_debug_format() {
+        let e = Error::Failed("test".into());
+        let dbg = format!("{:?}", e);
+        assert!(dbg.contains("Failed"));
+    }
+}

--- a/crates/phenotype-port-traits/Cargo.toml
+++ b/crates/phenotype-port-traits/Cargo.toml
@@ -13,5 +13,8 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+
 [lib]
 path = "src/lib.rs"

--- a/crates/phenotype-port-traits/src/lib.rs
+++ b/crates/phenotype-port-traits/src/lib.rs
@@ -68,3 +68,193 @@ pub trait CachePort: Send + Sync {
     ) -> Result<(), Self::Error>;
     async fn delete(&self, key: &str) -> Result<(), Self::Error>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // --- Mock Repository ---
+
+    #[derive(Debug, Clone)]
+    struct MockRepo {
+        store: std::sync::Arc<Mutex<HashMap<String, String>>>,
+    }
+
+    impl MockRepo {
+        fn new() -> Self {
+            Self {
+                store: std::sync::Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    struct MockError(String);
+
+    #[async_trait]
+    impl Repository<String> for MockRepo {
+        type Error = MockError;
+
+        async fn get(&self, id: &str) -> Result<Option<String>, Self::Error> {
+            Ok(self.store.lock().unwrap().get(id).cloned())
+        }
+
+        async fn save(&self, id: &str, entity: &String) -> Result<(), Self::Error> {
+            self.store
+                .lock()
+                .unwrap()
+                .insert(id.to_string(), entity.clone());
+            Ok(())
+        }
+
+        async fn delete(&self, id: &str) -> Result<(), Self::Error> {
+            self.store.lock().unwrap().remove(id);
+            Ok(())
+        }
+
+        async fn list(&self, offset: usize, limit: usize) -> Result<Vec<String>, Self::Error> {
+            let store = self.store.lock().unwrap();
+            let items: Vec<String> = store.values().cloned().collect();
+            Ok(items.into_iter().skip(offset).take(limit).collect())
+        }
+    }
+
+    // Traces to: FR-PHENO-020
+    #[tokio::test]
+    async fn repository_save_and_get() {
+        let repo = MockRepo::new();
+        repo.save("1", &"hello".to_string()).await.unwrap();
+        let val = repo.get("1").await.unwrap();
+        assert_eq!(val, Some("hello".to_string()));
+    }
+
+    // Traces to: FR-PHENO-020
+    #[tokio::test]
+    async fn repository_get_missing_returns_none() {
+        let repo = MockRepo::new();
+        let val = repo.get("nonexistent").await.unwrap();
+        assert!(val.is_none());
+    }
+
+    // Traces to: FR-PHENO-020
+    #[tokio::test]
+    async fn repository_delete() {
+        let repo = MockRepo::new();
+        repo.save("1", &"data".to_string()).await.unwrap();
+        repo.delete("1").await.unwrap();
+        assert!(repo.get("1").await.unwrap().is_none());
+    }
+
+    // Traces to: FR-PHENO-020
+    #[tokio::test]
+    async fn repository_exists_default_impl() {
+        let repo = MockRepo::new();
+        assert!(!repo.exists("1").await.unwrap());
+        repo.save("1", &"val".to_string()).await.unwrap();
+        assert!(repo.exists("1").await.unwrap());
+    }
+
+    // Traces to: FR-PHENO-020
+    #[tokio::test]
+    async fn repository_list_with_pagination() {
+        let repo = MockRepo::new();
+        for i in 0..5 {
+            repo.save(&i.to_string(), &format!("item-{i}"))
+                .await
+                .unwrap();
+        }
+        let page = repo.list(0, 3).await.unwrap();
+        assert_eq!(page.len(), 3);
+    }
+
+    // --- Mock EventPublisher ---
+
+    struct MockPublisher {
+        published: Mutex<Vec<(String, serde_json::Value)>>,
+    }
+
+    impl MockPublisher {
+        fn new() -> Self {
+            Self {
+                published: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl EventPublisher for MockPublisher {
+        type Error = MockError;
+
+        async fn publish(
+            &self,
+            topic: &str,
+            payload: &serde_json::Value,
+        ) -> Result<(), Self::Error> {
+            self.published
+                .lock()
+                .unwrap()
+                .push((topic.to_string(), payload.clone()));
+            Ok(())
+        }
+    }
+
+    // Traces to: FR-PHENO-021
+    #[tokio::test]
+    async fn event_publisher_publishes() {
+        let pub_ = MockPublisher::new();
+        let payload = serde_json::json!({"key": "value"});
+        pub_.publish("topic.a", &payload).await.unwrap();
+        let events = pub_.published.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "topic.a");
+    }
+
+    // --- Mock Notifier ---
+
+    struct MockNotifier {
+        sent: Mutex<Vec<(String, String, String)>>,
+    }
+
+    impl MockNotifier {
+        fn new() -> Self {
+            Self {
+                sent: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Notifier for MockNotifier {
+        type Error = MockError;
+
+        async fn notify(
+            &self,
+            recipient: &str,
+            subject: &str,
+            body: &str,
+        ) -> Result<(), Self::Error> {
+            self.sent.lock().unwrap().push((
+                recipient.to_string(),
+                subject.to_string(),
+                body.to_string(),
+            ));
+            Ok(())
+        }
+    }
+
+    // Traces to: FR-PHENO-022
+    #[tokio::test]
+    async fn notifier_sends() {
+        let n = MockNotifier::new();
+        n.notify("user@test.com", "Alert", "Server down")
+            .await
+            .unwrap();
+        let sent = n.sent.lock().unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].0, "user@test.com");
+        assert_eq!(sent[0].1, "Alert");
+    }
+}

--- a/crates/phenotype-state-machine/src/lib.rs
+++ b/crates/phenotype-state-machine/src/lib.rs
@@ -40,11 +40,14 @@ pub enum StateMachineError {
 /// Result type for state machine operations.
 pub type Result<T> = std::result::Result<T, StateMachineError>;
 
+/// Guard function type: takes (from_state, event) and returns whether transition is allowed.
+type GuardFn = Arc<dyn Fn(&str, &str) -> bool + Send + Sync>;
+
 /// A transition definition: (from_state, event) -> to_state with optional guard.
 #[derive(Clone)]
 struct Transition {
     to: String,
-    guard: Option<Arc<dyn Fn(&str, &str) -> bool + Send + Sync>>,
+    guard: Option<GuardFn>,
 }
 
 /// A generic finite state machine.
@@ -54,8 +57,8 @@ struct Transition {
 pub struct StateMachine {
     current: RwLock<String>,
     transitions: HashMap<(String, String), Transition>,
-    on_enter: HashMap<String, Vec<Arc<dyn Fn(&str) + Send + Sync>>>,
-    on_exit: HashMap<String, Vec<Arc<dyn Fn(&str) + Send + Sync>>>,
+    on_enter: HashMap<String, StateCallbacks>,
+    on_exit: HashMap<String, StateCallbacks>,
 }
 
 impl StateMachine {
@@ -137,12 +140,15 @@ impl fmt::Debug for StateMachine {
 unsafe impl Send for StateMachine {}
 unsafe impl Sync for StateMachine {}
 
+/// Callback list type for state enter/exit hooks.
+type StateCallbacks = Vec<Arc<dyn Fn(&str) + Send + Sync>>;
+
 /// Builder for constructing a [`StateMachine`].
 pub struct StateMachineBuilder {
     initial: String,
     transitions: HashMap<(String, String), Transition>,
-    on_enter: HashMap<String, Vec<Arc<dyn Fn(&str) + Send + Sync>>>,
-    on_exit: HashMap<String, Vec<Arc<dyn Fn(&str) + Send + Sync>>>,
+    on_enter: HashMap<String, StateCallbacks>,
+    on_exit: HashMap<String, StateCallbacks>,
 }
 
 impl StateMachineBuilder {

--- a/crates/phenotype-telemetry/src/metrics.rs
+++ b/crates/phenotype-telemetry/src/metrics.rs
@@ -21,3 +21,66 @@ impl Counter {
     pub fn inc(&self) { self.value.fetch_add(1, Ordering::Relaxed); }
     pub fn get(&self) -> u64 { self.value.load(Ordering::Relaxed) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Traces to: FR-PHENO-010
+    #[test]
+    fn counter_starts_at_zero() {
+        let c = Counter::new();
+        assert_eq!(c.get(), 0);
+    }
+
+    // Traces to: FR-PHENO-010
+    #[test]
+    fn counter_default_starts_at_zero() {
+        let c = Counter::default();
+        assert_eq!(c.get(), 0);
+    }
+
+    // Traces to: FR-PHENO-010
+    #[test]
+    fn counter_increments() {
+        let c = Counter::new();
+        c.inc();
+        c.inc();
+        c.inc();
+        assert_eq!(c.get(), 3);
+    }
+
+    // Traces to: FR-PHENO-010
+    #[test]
+    fn counter_clone_via_arc_shares_state() {
+        let c = Counter::new();
+        // The inner Arc means cloning the struct shares state
+        let c2 = Counter {
+            value: Arc::clone(&c.value),
+        };
+        c.inc();
+        c2.inc();
+        assert_eq!(c.get(), 2);
+        assert_eq!(c2.get(), 2);
+    }
+
+    // Traces to: FR-PHENO-010
+    #[test]
+    fn counter_concurrent_increments() {
+        let c = Counter::new();
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let val = Arc::clone(&c.value);
+                std::thread::spawn(move || {
+                    for _ in 0..100 {
+                        val.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(c.get(), 1000);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 27 new tests across 4 previously-untested crates: phenotype-errors, phenotype-telemetry (Counter), phenotype-port-traits (mock Repository/EventPublisher/Notifier), agileplus-api-types (ApiResponse)
- Fix pre-existing clippy type_complexity warnings in phenotype-state-machine via type aliases
- All `cargo test --workspace` and `cargo clippy --workspace -- -D warnings` pass clean

## Test plan
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)