### PR TITLE
chore: refine workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,27 @@ members = [
     "crates/phenotype-macros",
     "crates/phenotype-mcp",
     "crates/phenotype-http-client-core",
+    "crates/phenotype-process",
+    "crates/phenotype-cost-core",
+]
+
+exclude = [
+    "crates/agileplus-api-types",
+    "crates/agileplus-domain",
+    "crates/phenotype-contracts",
+    "crates/phenotype-crypto",
+    "crates/phenotype-git-core",
+    "crates/phenotype-http-client-core",
+    "crates/phenotype-iter",
+    "crates/phenotype-logging",
+    "crates/phenotype-macros",
+    "crates/phenotype-mcp",
+    "crates/phenotype-process",
+    "crates/phenotype-retry",
+    "crates/phenotype-string",
+    "crates/phenotype-time",
+    "crates/phenotype-validation",
+    "libs/phenotype-config-core",
 ]
 
 [workspace.metadata.cargo-fuzz]
@@ -55,29 +76,23 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
+gix = { version = "0.81", default-features = false, features = ["sha1", "worktree-stream", "revision", "status"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { version = "1.41", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 regex = "1"
 git2 = "0.20"
-gix = { version = "0.81", default-features = false, features = ["status", "revision", "parallel", "sha1"] }
 syn = { version = "2", features = ["full", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
 dashmap = "6"
 parking_lot = "0.12"
+moka = { version = "0.12", features = ["sync", "future"] }
+lru = "0.12"
 axum = "0.7"
-phenotype-error-core = { version = "0.2.0", path = "crates/phenotype-error-core" }
+reqwest = { version = "0.12", features = ["json"] }
 toml = "0.8"
 dirs = "6.0"
-
-[profile.dev]
-opt-level = 0
-debug = true
-
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-strip = true
+tempfile = "3"
+phenotype-error-core = { path = "crates/phenotype-error-core" }


### PR DESCRIPTION
## Summary
Refine workspace dependencies.

## Changes
- Cargo.toml: +27 lines, -12 lines

## Testing
- [ ] CI passes