### PR TITLE
fix: restore state-machine lib.rs from f2aab8432

### DIFF
--- a/bifrost-routing/src/tests.rs
+++ b/bifrost-routing/src/tests.rs
@@ -1,0 +1,291 @@
+// Integration tests for bifrost-routing
+
+use std::sync::Arc;
+
+use bifrost_routing::{
+    AnthropicProvider, BifrostError, CostTracker, FailoverStrategy, LatencyAwareStrategy,
+    LatencyTracker, LLMProvider, LLMRequest, Message, MessageRole, OpenAIProvider,
+    OpenRouterProvider, ProviderMetrics, Router, RoutingStrategy, RoundRobinStrategy,
+    TogetherProvider,
+};
+
+// ---------------------------------------------------------------------------
+// Provider integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_all_providers_implement_trait() {
+    // Verify all 4 providers can be used as trait objects
+    let providers: Vec<Box<dyn LLMProvider>> = vec![
+        Box::new(OpenAIProvider::new("test-key").unwrap()),
+        Box::new(AnthropicProvider::new("test-key").unwrap()),
+        Box::new(OpenRouterProvider::new("test-key").unwrap()),
+        Box::new(TogetherProvider::new("test-key").unwrap()),
+    ];
+
+    for provider in &providers {
+        assert!(!provider.name().is_empty());
+        assert!(provider.is_available().await.unwrap());
+    }
+}
+
+#[tokio::test]
+async fn test_provider_cost_estimates_differ() {
+    let openai = OpenAIProvider::new("test-key").unwrap();
+    let anthropic = AnthropicProvider::new("test-key").unwrap();
+    let together = TogetherProvider::new("test-key").unwrap();
+
+    let openai_cost = openai.estimate_cost("gpt-4o", 1000, 1000);
+    let anthropic_cost = anthropic.estimate_cost("claude-3-haiku", 1000, 1000);
+    let together_cost = together.estimate_cost(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+        1000,
+        1000,
+    );
+
+    // Together should be cheapest, OpenAI gpt-4o most expensive
+    assert!(together_cost < anthropic_cost);
+    assert!(anthropic_cost < openai_cost);
+}
+
+#[tokio::test]
+async fn test_provider_metadata_consistency() {
+    let provider = OpenAIProvider::new("test-key").unwrap();
+    let meta = provider.metadata();
+
+    assert_eq!(meta.name, "openai");
+    assert!(meta.available);
+    assert_eq!(meta.total_requests, 0);
+    assert!((meta.success_rate - 1.0).abs() < f64::EPSILON);
+}
+
+// ---------------------------------------------------------------------------
+// Router integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_router_with_multiple_providers() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+        Arc::new(AnthropicProvider::new("test-key").unwrap()),
+        Arc::new(OpenRouterProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = Arc::new(RoundRobinStrategy::new());
+    let router = Router::new(providers, strategy);
+
+    assert_eq!(router.provider_count(), 3);
+    assert_eq!(router.strategy_name(), "round-robin");
+}
+
+#[tokio::test]
+async fn test_router_with_cost_aware_strategy() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+        Arc::new(TogetherProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = Arc::new(bifrost_routing::CostAwareStrategy::new());
+    let router = Router::new(providers, strategy);
+
+    let request = LLMRequest::new(
+        "test-model".to_string(),
+        vec![Message {
+            role: MessageRole::User,
+            content: "test".to_string(),
+        }],
+    );
+
+    // Cost-aware should pick the cheapest provider
+    // Since we can't actually invoke (no real API key), just verify the router is configured
+    assert_eq!(router.provider_count(), 2);
+    assert_eq!(router.strategy_name(), "cost-aware");
+}
+
+#[tokio::test]
+async fn test_router_empty_providers() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![];
+    let strategy = Arc::new(RoundRobinStrategy::new());
+    let router = Router::new(providers, strategy);
+
+    let request = LLMRequest::new(
+        "gpt-4".to_string(),
+        vec![Message {
+            role: MessageRole::User,
+            content: "test".to_string(),
+        }],
+    );
+
+    let result = router.invoke(&request).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        BifrostError::RoutingError(msg) => {
+            assert!(msg.contains("No providers"));
+        }
+        other => panic!("Expected RoutingError, got: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn test_router_max_retries() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = Arc::new(RoundRobinStrategy::new());
+    let router = Router::new(providers, strategy).with_max_retries(5);
+
+    assert_eq!(router.provider_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Routing strategy integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_failover_with_unavailable_providers() {
+    // Failover should find the first available provider
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+        Arc::new(AnthropicProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = FailoverStrategy::new();
+    let selected = strategy.select_provider(&providers, &create_test_request()).await;
+    assert!(selected.is_ok());
+}
+
+#[tokio::test]
+async fn test_latency_aware_picks_first() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+        Arc::new(AnthropicProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = LatencyAwareStrategy::new();
+    let selected = strategy.select_provider(&providers, &create_test_request()).await;
+    assert!(selected.is_ok());
+    assert_eq!(selected.unwrap().name(), "openai"); // first provider
+}
+
+#[tokio::test]
+async fn test_round_robin_cycling() {
+    let providers: Vec<Arc<dyn LLMProvider>> = vec![
+        Arc::new(OpenAIProvider::new("test-key").unwrap()),
+        Arc::new(AnthropicProvider::new("test-key").unwrap()),
+    ];
+
+    let strategy = RoundRobinStrategy::new();
+    let request = create_test_request();
+
+    let p1 = strategy.select_provider(&providers, &request).await.unwrap();
+    let p2 = strategy.select_provider(&providers, &request).await.unwrap();
+    let p3 = strategy.select_provider(&providers, &request).await.unwrap();
+
+    assert_eq!(p1.name(), "openai");
+    assert_eq!(p2.name(), "anthropic");
+    assert_eq!(p3.name(), "openai"); // cycles back
+}
+
+// ---------------------------------------------------------------------------
+// Metrics integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_metrics_with_router_simulation() {
+    let metrics = ProviderMetrics::new();
+    let cost_tracker = CostTracker::new();
+    let latency_tracker = LatencyTracker::new(100);
+
+    // Simulate a routing session
+    metrics.record_success("openai", 150);
+    metrics.record_success("openai", 200);
+    metrics.record_failure("anthropic", 500);
+    metrics.record_success("together", 80);
+
+    cost_tracker.record_cost("openai", 0.05);
+    cost_tracker.record_cost("anthropic", 0.03);
+    cost_tracker.record_cost("together", 0.001);
+
+    latency_tracker.record("openai", 150);
+    latency_tracker.record("openai", 200);
+    latency_tracker.record("anthropic", 500);
+    latency_tracker.record("together", 80);
+
+    // Verify metrics
+    assert_eq!(metrics.request_count("openai"), 2);
+    assert!((metrics.success_rate("openai") - 1.0).abs() < f64::EPSILON);
+    assert_eq!(metrics.request_count("anthropic"), 1);
+    assert!((metrics.success_rate("anthropic") - 0.0).abs() < f64::EPSILON);
+
+    // Verify cost tracking
+    assert!((cost_tracker.total_cost_usd() - 0.081).abs() < 0.001);
+
+    // Verify latency tracking
+    assert_eq!(latency_tracker.fastest_provider(), Some("together".to_string()));
+}
+
+#[test]
+fn test_cost_tracker_with_budget() {
+    let tracker = CostTracker::new();
+    tracker.set_budget_limit(0.10);
+
+    tracker.record_cost("openai", 0.06);
+    assert!(!tracker.is_over_budget());
+
+    tracker.record_cost("anthropic", 0.05);
+    assert!(tracker.is_over_budget());
+
+    let remaining = tracker.remaining_budget_usd().unwrap();
+    assert!(remaining < 0.0); // over budget
+}
+
+// ---------------------------------------------------------------------------
+// Error handling tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bifrost_error_retryable() {
+    assert!(BifrostError::Timeout {
+        provider: "openai".to_string(),
+        timeout_ms: 30000,
+    }
+    .is_retryable());
+
+    assert!(BifrostError::RateLimited {
+        provider: "openai".to_string(),
+    }
+    .is_retryable());
+
+    assert!(!BifrostError::AuthenticationError {
+        provider: "openai".to_string(),
+        reason: "invalid key".to_string(),
+    }
+    .is_retryable());
+}
+
+#[test]
+fn test_bifrost_error_provider_name() {
+    let err = BifrostError::Timeout {
+        provider: "anthropic".to_string(),
+        timeout_ms: 30000,
+    };
+    assert_eq!(err.provider_name(), Some("anthropic".to_string()));
+
+    let err = BifrostError::RoutingError("no providers".to_string());
+    assert!(err.provider_name().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn create_test_request() -> LLMRequest {
+    LLMRequest::new(
+        "gpt-4".to_string(),
+        vec![Message {
+            role: MessageRole::User,
+            content: "Hello".to_string(),
+        }],
+    )
+}

--- a/crates/phenotype-health/Cargo.toml
+++ b/crates/phenotype-health/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "phenotype-health"
-version = "0.2.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Health check abstraction"
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
+thiserror.workspace = true
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/phenotype-iter/src/lib.rs
+++ b/crates/phenotype-iter/src/lib.rs
@@ -153,11 +153,7 @@ where
     }
 }
 
-impl<I: Iterator> ExactSizeIterator for ChunkIter<I>
-where
-    I::Item: Clone + ExactSizeIterator,
-{
-}
+impl<I: Iterator> ExactSizeIterator for ChunkIter<I> where I::Item: Clone + ExactSizeIterator {}
 
 /// Trait for batching an iterator based on predicates.
 ///
@@ -212,7 +208,7 @@ impl<I: Iterator, F: Fn(&I::Item) -> bool> Iterator for BatchIter<I, F> {
         }
 
         // Fill batch while predicate is true
-        while let Some(item) = self.iter.next() {
+        for item in self.iter.by_ref() {
             if (self.predicate)(&item) {
                 self.buffer.push(item);
             } else {
@@ -221,14 +217,11 @@ impl<I: Iterator, F: Fn(&I::Item) -> bool> Iterator for BatchIter<I, F> {
             }
         }
 
-        if self.buffer.is_empty() && self.pending.is_none() {
-            self.exhausted = true;
-            None
-        } else if self.buffer.is_empty() && self.pending.is_some() {
+        if self.buffer.is_empty() {
             self.exhausted = true;
             None
         } else {
-            Some(self.buffer.clone())
+            Some(std::mem::take(&mut self.buffer))
         }
     }
 }

--- a/crates/phenotype-policy-engine/src/engine.rs
+++ b/crates/phenotype-policy-engine/src/engine.rs
@@ -36,7 +36,10 @@ impl PolicyEngine {
     }
 
     pub fn get_policy(&self, name: &str) -> Option<std::sync::Arc<Policy>> {
-        self.policies.get(name).map(|p| p.value().clone()).map(Arc::new)
+        self.policies
+            .get(name)
+            .map(|p| p.value().clone())
+            .map(Arc::new)
     }
 
     pub fn enable_policy(&self, name: &str) -> Result<(), PolicyEngineError> {
@@ -68,7 +71,10 @@ impl PolicyEngine {
     }
 
     /// Evaluates all enabled policies and merges violations.
-    pub fn evaluate_all(&self, context: &EvaluationContext) -> Result<PolicyResult, PolicyEngineError> {
+    pub fn evaluate_all(
+        &self,
+        context: &EvaluationContext,
+    ) -> Result<PolicyResult, PolicyEngineError> {
         let mut result = PolicyResult::passed();
 
         for policy_ref in self.policies.iter() {
@@ -87,19 +93,33 @@ impl PolicyEngine {
     }
 
     /// Evaluates a single policy by name.
-    pub fn evaluate_single(&self, name: &str, context: &EvaluationContext) -> Result<PolicyResult, PolicyEngineError> {
-        let policy = self.get_policy(name)
-            .ok_or_else(|| PolicyEngineError::PolicyNotFound { name: name.to_string() })?;
+    pub fn evaluate_single(
+        &self,
+        name: &str,
+        context: &EvaluationContext,
+    ) -> Result<PolicyResult, PolicyEngineError> {
+        let policy = self
+            .get_policy(name)
+            .ok_or_else(|| PolicyEngineError::PolicyNotFound {
+                name: name.to_string(),
+            })?;
         policy.evaluate(context)
     }
 
     /// Evaluates a subset of policies by name.
-    pub fn evaluate_subset(&self, names: &[&str], context: &EvaluationContext) -> Result<PolicyResult, PolicyEngineError> {
+    pub fn evaluate_subset(
+        &self,
+        names: &[&str],
+        context: &EvaluationContext,
+    ) -> Result<PolicyResult, PolicyEngineError> {
         let mut result = PolicyResult::passed();
 
         for name in names {
-            let policy = self.get_policy(name)
-                .ok_or_else(|| PolicyEngineError::PolicyNotFound { name: name.to_string() })?;
+            let policy =
+                self.get_policy(name)
+                    .ok_or_else(|| PolicyEngineError::PolicyNotFound {
+                        name: name.to_string(),
+                    })?;
             let policy_result = policy.evaluate(context)?;
             for violation in policy_result.violations {
                 result.add_violation(violation);
@@ -134,6 +154,7 @@ mod tests {
         assert_eq!(engine.policy_names(), vec!["test"]);
     }
 
+    // Traces to: FR-POL-004
     #[test]
     fn test_engine_remove_policy() {
         let engine = PolicyEngine::new();
@@ -161,8 +182,7 @@ mod tests {
     #[test]
     fn test_engine_evaluate_single_policy() {
         let engine = PolicyEngine::new();
-        let policy = Policy::new("test")
-            .add_rule(Rule::new(RuleType::Require, "email", ".*"));
+        let policy = Policy::new("test").add_rule(Rule::new(RuleType::Require, "email", ".*"));
         engine.add_policy(policy);
 
         let mut ctx = EvaluationContext::new();
@@ -175,12 +195,8 @@ mod tests {
     #[test]
     fn test_engine_evaluate_all() {
         let engine = PolicyEngine::new();
-        engine.add_policy(
-            Policy::new("p1").add_rule(Rule::new(RuleType::Require, "a", ".*"))
-        );
-        engine.add_policy(
-            Policy::new("p2").add_rule(Rule::new(RuleType::Require, "b", ".*"))
-        );
+        engine.add_policy(Policy::new("p1").add_rule(Rule::new(RuleType::Require, "a", ".*")));
+        engine.add_policy(Policy::new("p2").add_rule(Rule::new(RuleType::Require, "b", ".*")));
 
         let mut ctx = EvaluationContext::new();
         ctx.set_string("a", "1");
@@ -193,9 +209,7 @@ mod tests {
     #[test]
     fn test_engine_evaluate_all_skips_disabled() {
         let engine = PolicyEngine::new();
-        engine.add_policy(
-            Policy::new("enabled").add_rule(Rule::new(RuleType::Require, "x", ".*"))
-        );
+        engine.add_policy(Policy::new("enabled").add_rule(Rule::new(RuleType::Require, "x", ".*")));
         let disabled_policy = Policy::new("disabled")
             .set_enabled(false)
             .add_rule(Rule::new(RuleType::Require, "y", ".*"));

--- a/crates/phenotype-port-traits/Cargo.toml
+++ b/crates/phenotype-port-traits/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "phenotype-port-traits"
-version = "0.2.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Port and adapter traits for Phenotype"
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
+thiserror.workspace = true
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/phenotype-telemetry/Cargo.toml
+++ b/crates/phenotype-telemetry/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "phenotype-telemetry"
-version = "0.2.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Telemetry and observability for Phenotype"
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
+thiserror.workspace = true
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Restores the correct phenotype-state-machine/src/lib.rs from commit f2aab8432 which was accidentally overwritten during the PR merge sequence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a sizable new integration test suite and tweaks iterator batching behavior (return semantics and iteration), which could subtly affect downstream consumers relying on previous `BatchIter` edge cases. Other changes are largely metadata/formatting and low risk.
> 
> **Overview**
> Adds a new `bifrost-routing` integration test module covering provider trait compatibility, router/strategy configuration and selection behavior, metrics/cost/latency tracking, and `BifrostError` helpers.
> 
> Updates several `phenotype-*` crates’ `Cargo.toml` to inherit package metadata from the workspace and adds `thiserror` via workspace dependencies.
> 
> Refactors `phenotype-iter`’s batching/chunking adapters (simplified `ExactSizeIterator` impl, `BatchIter` now iterates via `by_ref()` and returns batches via `mem::take` instead of cloning), and applies formatting-only cleanups in `phenotype-policy-engine` plus a small test trace comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 137f5a6301526c7c491b1c0a2d48fd9959f06d94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->