### PR TITLE
chore: ignore AgilePlus directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,4 @@ crates/phenotype-contracts/tests/
 .hypothesis/
 >>>>>>> origin/main
 >>>>>>> origin/main
+AgilePlus/


### PR DESCRIPTION
Add AgilePlus/ to .gitignore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore`; it only affects which local files are excluded from version control.
> 
> **Overview**
> Adds `AgilePlus/` to `.gitignore` so the `AgilePlus` directory is no longer tracked/accidentally committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eee55164057bca1ed568ffceebf1553028eea25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->