### PR TITLE
feat(workspace): add phenotype crates with fixes

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -33,5 +33,28 @@ brew "grpcurl"
 brew "python@3.12"
 brew "uv"
 
+# Modern Terminal UX/DX Extras (2026 Audit)
+brew "fastfetch"
+brew "gping"
+brew "ouch"
+brew "doggo"
+brew "bottom"
+brew "yazi"
+brew "atuin"
+brew "eza"
+brew "bat"
+brew "fd"
+brew "ripgrep"
+brew "btop"
+brew "dust"
+brew "duf"
+brew "zoxide"
+brew "fzf"
+brew "delta"
+
+# TypeScript 7 Native (tsgo)
+# brew install @rslint/tsgo via npm or brew tap if available
+# Current implementation: npm install -g @rslint/tsgo
+
 # Container runtime (Dragonfly, Plane.so postgres)
 cask "orbstack"

--- a/crates/phenotype-config/Cargo.toml
+++ b/crates/phenotype-config/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "phenotype-config"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Configuration management for Phenotype using figment"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+figment = { version = "0.10", features = ["toml", "env"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/crates/phenotype-config/src/lib.rs
+++ b/crates/phenotype-config/src/lib.rs
@@ -1,0 +1,197 @@
+//! # Phenotype Config Library
+//!
+//! Configuration management for Phenotype using figment with support for:
+//! - TOML files
+//! - Environment variables  
+//! - JSON files
+//!
+//! ## Features
+//!
+//! - Multi-source configuration (file, env, defaults)
+//! - Nested configuration with profiles
+//! - Schema validation
+//! - Type-safe accessors
+
+use figment::{Figment, providers::{Env, Format, Json, Toml}};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Configuration source priority (highest wins)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Source {
+    /// Default values (lowest priority)
+    Default = 0,
+    /// TOML configuration file
+    File = 1,
+    /// JSON configuration file
+    Json = 2,
+    /// Environment variables (highest priority)
+    Env = 3,
+}
+
+/// Configuration error types
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("configuration error: {0}")]
+    Figment(#[from] figment::Error),
+    
+    #[error("missing required field: {0}")]
+    MissingField(String),
+    
+    #[error("invalid value for {field}: {message}")]
+    InvalidValue { field: String, message: String },
+}
+
+/// Result type for configuration operations
+pub type Result<T> = std::result::Result<T, ConfigError>;
+
+/// Load configuration from the default sources
+/// 
+/// Priority (highest wins):
+/// 1. Environment variables (PHENO_ prefix)
+/// 2. config.toml in current directory
+/// 3. Default values
+pub fn load<T: DeserializeOwned>() -> Result<T> {
+    load_with_profile::<T>("default")
+}
+
+/// Load configuration with a specific profile
+pub fn load_with_profile<T: DeserializeOwned>(profile: &str) -> Result<T> {
+    let figment = Figment::new()
+        .merge(Toml::file("config.toml").profile(profile))
+        .merge(Env::prefixed("PHENO_"));
+    
+    figment.extract()
+}
+
+/// Load configuration from a specific file
+pub fn load_from_file<T: DeserializeOwned, P: AsRef<PathBuf>>(
+    path: P,
+) -> Result<T> {
+    let path = path.as_ref();
+    let ext = path.extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("toml");
+    
+    let figment = match ext {
+        "json" => Figment::new().merge(Json::file(path)),
+        _ => Figment::new().merge(Toml::file(path)),
+    };
+    
+    figment.extract()
+}
+
+/// Add a data source to the configuration
+pub struct ConfigBuilder {
+    figment: Figment,
+}
+
+impl ConfigBuilder {
+    /// Create a new configuration builder
+    pub fn new() -> Self {
+        Self {
+            figment: Figment::new(),
+        }
+    }
+    
+    /// Add a TOML file as a configuration source
+    pub fn with_toml_file<P: AsRef<PathBuf>>(mut self, path: P) -> Self {
+        self.figment = self.figment.merge(Toml::file(path));
+        self
+    }
+    
+    /// Add a JSON file as a configuration source
+    pub fn with_json_file<P: AsRef<PathBuf>>(mut self, path: P) -> Self {
+        self.figment = self.figment.merge(Json::file(path));
+        self
+    }
+    
+    /// Add environment variables with a prefix
+    pub fn with_env_prefixed(mut self, prefix: &str) -> Self {
+        self.figment = self.figment.merge(Env::prefixed(prefix));
+        self
+    }
+    
+    /// Extract the configuration
+    pub fn extract<T: DeserializeOwned>(self) -> Result<T> {
+        self.figment.extract()
+    }
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Helper trait for type-safe configuration access
+pub trait ConfigExt: Sized + DeserializeOwned {
+    /// Load from default sources
+    fn load() -> Result<Self> {
+        load_with_profile::<Self>("default")
+    }
+    
+    /// Load with a specific profile
+    fn load_with_profile(profile: &str) -> Result<Self> {
+        load_with_profile::<Self>(profile)
+    }
+    
+    /// Load from a specific file
+    fn load_from_file<P: AsRef<PathBuf>>(path: P) -> Result<Self> {
+        load_from_file::<Self, P>(path)
+    }
+    
+    /// Create a configuration builder
+    fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+    }
+}
+
+impl<T: DeserializeOwned> ConfigExt for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_load_from_defaults() {
+        #[derive(Deserialize, Default)]
+        struct Defaults {
+            name: String,
+            port: u16,
+        }
+        
+        impl Defaults {
+            fn load_with_defaults() -> Self {
+                Self {
+                    name: "default".to_string(),
+                    port: 8080,
+                }
+            }
+        }
+        
+        let config = Defaults::load_with_defaults();
+        assert_eq!(config.name, "default");
+        assert_eq!(config.port, 8080);
+    }
+    
+    #[test]
+    fn test_config_builder() {
+        let config: HashMap<String, String> = ConfigBuilder::new()
+            .with_env_prefixed("TEST_")
+            .extract()
+            .unwrap_or_default();
+        
+        // Should not panic
+        assert!(true);
+    }
+    
+    #[test]
+    fn test_source_priority() {
+        assert!(Source::Env > Source::Json);
+        assert!(Source::Json > Source::File);
+        assert!(Source::File > Source::Default);
+    }
+}

--- a/crates/phenotype-mcp/src/error.rs
+++ b/crates/phenotype-mcp/src/error.rs
@@ -1,0 +1,100 @@
+//! Error types for MCP protocol operations
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// MCP protocol error codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ErrorCode {
+    /// Invalid Request: The JSON sent is not a valid Request object
+    #[serde(rename = "-32600")]
+    InvalidRequest = -32600,
+    /// Method not found: The method does not exist or is not available
+    #[serde(rename = "-32601")]
+    MethodNotFound = -32601,
+    /// Invalid params: Invalid method parameter(s)
+    #[serde(rename = "-32602")]
+    InvalidParams = -32602,
+    /// Internal error: Internal JSON-RPC error
+    #[serde(rename = "-32603")]
+    InternalError = -32603,
+    /// Server error: Server error (reserved for implementation-defined server errors)
+    #[serde(rename = "-32000")]
+    ServerError = -32000,
+    /// Parse error: Invalid JSON was received by the server
+    #[serde(rename = "-32700")]
+    ParseError = -32700,
+}
+
+/// Result type for MCP operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// MCP error type
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("method not found: {0}")]
+    MethodNotFound(String),
+
+    #[error("invalid params: {0}")]
+    InvalidParams(String),
+
+    #[error("internal error: {0}")]
+    InternalError(String),
+
+    #[error("server error: {0}")]
+    ServerError(String),
+
+    #[error("parse error: {0}")]
+    ParseError(String),
+
+    #[error("serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("anyhow error: {0}")]
+    Other(#[from] anyhow::Error),
+}
+
+impl Error {
+    /// Get the error code for this error
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            Error::InvalidRequest(_) => ErrorCode::InvalidRequest,
+            Error::MethodNotFound(_) => ErrorCode::MethodNotFound,
+            Error::InvalidParams(_) => ErrorCode::InvalidParams,
+            Error::InternalError(_) => ErrorCode::InternalError,
+            Error::ServerError(_) => ErrorCode::ServerError,
+            Error::ParseError(_) => ErrorCode::ParseError,
+            Error::SerializationError(_) => ErrorCode::ParseError,
+            Error::Other(_) => ErrorCode::InternalError,
+        }
+    }
+
+    /// Get error message
+    pub fn message(&self) -> String {
+        self.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_codes() {
+        assert_eq!(ErrorCode::InvalidRequest as i32, -32600);
+        assert_eq!(ErrorCode::MethodNotFound as i32, -32601);
+        assert_eq!(ErrorCode::InvalidParams as i32, -32602);
+        assert_eq!(ErrorCode::InternalError as i32, -32603);
+        assert_eq!(ErrorCode::ServerError as i32, -32000);
+        assert_eq!(ErrorCode::ParseError as i32, -32700);
+    }
+
+    #[test]
+    fn test_error_code_from_error() {
+        let err = Error::MethodNotFound("test_method".into());
+        assert_eq!(err.code(), ErrorCode::MethodNotFound);
+    }
+}

--- a/crates/phenotype-mcp/src/jsonrpc.rs
+++ b/crates/phenotype-mcp/src/jsonrpc.rs
@@ -1,0 +1,169 @@
+//! JSON-RPC 2.0 message types for MCP protocol
+
+use crate::error::Error;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// JSON-RPC 2.0 request message
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcRequest {
+    /// A String specifying the version of the JSON-RPC protocol to be used. MUST be exactly "2.0".
+    pub jsonrpc: String,
+    /// A String containing the name of the method to be invoked.
+    pub method: String,
+    /// A Structured value that holds the parameter values to be used during the invocation of the method. OPTIONAL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    /// An identifier established by the Client. If it is not included it is assumed to be a notification. OPTIONAL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+}
+
+impl JsonRpcRequest {
+    /// Create a new JSON-RPC request
+    pub fn new(method: impl Into<String>, params: Option<Value>, id: Option<Value>) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            method: method.into(),
+            params,
+            id,
+        }
+    }
+
+    /// Check if this is a notification (no id field)
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+/// JSON-RPC 2.0 response message
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcResponse {
+    /// A String specifying the version of the JSON-RPC protocol to be used. MUST be exactly "2.0".
+    pub jsonrpc: String,
+    /// The result of the method invocation. REQUIRED on success, MUST NOT exist in case of error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// An Error Object in case a method invocation has caused an error. MUST NOT exist in case of success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    /// It MUST be the same as the value of the id member in the Request Object.
+    pub id: Value,
+}
+
+impl JsonRpcResponse {
+    /// Create a successful JSON-RPC response
+    pub fn success(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    /// Create an error JSON-RPC response
+    pub fn error(id: Value, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            result: None,
+            error: Some(error),
+            id,
+        }
+    }
+
+    /// Check if this response contains an error
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
+    }
+}
+
+/// JSON-RPC 2.0 error object
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonRpcError {
+    /// A Number that indicates the error type that occurred.
+    pub code: i32,
+    /// A String providing a short description of the error.
+    pub message: String,
+    /// A Primitive or Structured value that contains additional information about the error. OPTIONAL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    /// Create a new JSON-RPC error
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// Create a JSON-RPC error with data
+    pub fn with_data(code: i32, message: impl Into<String>, data: Value) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: Some(data),
+        }
+    }
+}
+
+/// JSON-RPC message (request or response)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcMessage {
+    /// A request message
+    Request(JsonRpcRequest),
+    /// A response message
+    Response(JsonRpcResponse),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jsonrpc_request_new() {
+        let req = JsonRpcRequest::new("test_method", None, Some(Value::Number(1.into())));
+        assert_eq!(req.jsonrpc, "2.0");
+        assert_eq!(req.method, "test_method");
+        assert!(req.params.is_none());
+        assert!(!req.is_notification());
+    }
+
+    #[test]
+    fn test_jsonrpc_request_notification() {
+        let req = JsonRpcRequest::new("notify_method", None, None);
+        assert!(req.is_notification());
+    }
+
+    #[test]
+    fn test_jsonrpc_response_success() {
+        let resp = JsonRpcResponse::success(Value::Number(1.into()), json!({"status": "ok"}));
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert!(!resp.is_error());
+    }
+
+    #[test]
+    fn test_jsonrpc_response_error() {
+        let err = JsonRpcError::new(-32600, "Invalid Request");
+        let resp = JsonRpcResponse::error(Value::Number(1.into()), err);
+        assert!(resp.is_error());
+    }
+
+    #[test]
+    fn test_jsonrpc_error_with_data() {
+        let data = json!({"details": "something"});
+        let err = JsonRpcError::with_data(-32603, "Internal error", data.clone());
+        assert_eq!(err.data, Some(data));
+    }
+
+    // Helper macro for tests
+    macro_rules! json {
+        ($($json:tt)*) => {
+            serde_json::json!($($json)*)
+        };
+    }
+}

--- a/crates/phenotype-mcp/src/messages.rs
+++ b/crates/phenotype-mcp/src/messages.rs
@@ -1,0 +1,256 @@
+//! MCP protocol message types
+
+use crate::{ClientInfo, ServerInfo};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Client message types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method")]
+pub enum ClientMessage {
+    /// Initialize connection
+    #[serde(rename = "initialize")]
+    Initialize(InitializeRequest),
+}
+
+/// Server message types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method")]
+pub enum ServerMessage {
+    /// Initialize response
+    #[serde(rename = "initialize")]
+    Initialize(InitializeResponse),
+}
+
+/// Initialize request from client
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InitializeRequest {
+    /// Protocol version (e.g., "2024-11-05")
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    /// Client capabilities
+    pub capabilities: ClientCapabilities,
+    /// Client information
+    pub clientInfo: ClientInfo,
+}
+
+impl InitializeRequest {
+    /// Create a new initialize request
+    pub fn new(client_info: ClientInfo) -> Self {
+        Self {
+            protocol_version: "2024-11-05".into(),
+            capabilities: ClientCapabilities::default(),
+            clientInfo: client_info,
+        }
+    }
+}
+
+/// Initialize response from server
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InitializeResponse {
+    /// Protocol version (e.g., "2024-11-05")
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    /// Server capabilities
+    pub capabilities: ServerCapabilities,
+    /// Server information
+    pub serverInfo: ServerInfo,
+}
+
+impl InitializeResponse {
+    /// Create a new initialize response
+    pub fn new(server_info: ServerInfo) -> Self {
+        Self {
+            protocol_version: "2024-11-05".into(),
+            capabilities: ServerCapabilities::default(),
+            serverInfo: server_info,
+        }
+    }
+}
+
+/// Client capabilities
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClientCapabilities {
+    /// Whether client supports experimental features
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, Value>>,
+}
+
+impl Default for ClientCapabilities {
+    fn default() -> Self {
+        Self { experimental: None }
+    }
+}
+
+/// Server capabilities
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ServerCapabilities {
+    /// Tool capabilities
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<ToolCapability>,
+    /// Resource capabilities
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourceCapability>,
+    /// Prompt capabilities
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<PromptCapability>,
+    /// Whether experimental features are supported
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, Value>>,
+}
+
+impl Default for ServerCapabilities {
+    fn default() -> Self {
+        Self {
+            tools: Some(ToolCapability::default()),
+            resources: Some(ResourceCapability::default()),
+            prompts: Some(PromptCapability::default()),
+            experimental: None,
+        }
+    }
+}
+
+impl ServerCapabilities {
+    /// Create a new server capabilities with all features enabled
+    pub fn full() -> Self {
+        Self::default()
+    }
+
+    /// Create server capabilities with only tools enabled
+    pub fn tools_only() -> Self {
+        Self {
+            tools: Some(ToolCapability::default()),
+            resources: None,
+            prompts: None,
+            experimental: None,
+        }
+    }
+
+    /// Create server capabilities with only resources enabled
+    pub fn resources_only() -> Self {
+        Self {
+            tools: None,
+            resources: Some(ResourceCapability::default()),
+            prompts: None,
+            experimental: None,
+        }
+    }
+
+    /// Create server capabilities with only prompts enabled
+    pub fn prompts_only() -> Self {
+        Self {
+            tools: None,
+            resources: None,
+            prompts: Some(PromptCapability::default()),
+            experimental: None,
+        }
+    }
+}
+
+/// Tool capability
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCapability {
+    /// Whether tool listing is supported
+    #[serde(default)]
+    pub list_changed: bool,
+}
+
+impl Default for ToolCapability {
+    fn default() -> Self {
+        Self { list_changed: true }
+    }
+}
+
+/// Resource capability
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourceCapability {
+    /// Whether resource listing is supported
+    #[serde(default)]
+    pub subscribe: bool,
+    /// Whether resource list changes are supported
+    #[serde(default)]
+    pub list_changed: bool,
+}
+
+impl Default for ResourceCapability {
+    fn default() -> Self {
+        Self {
+            subscribe: true,
+            list_changed: true,
+        }
+    }
+}
+
+/// Prompt capability
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PromptCapability {
+    /// Whether prompt listing is supported
+    #[serde(default)]
+    pub list_changed: bool,
+}
+
+impl Default for PromptCapability {
+    fn default() -> Self {
+        Self { list_changed: true }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initialize_request() {
+        let client_info = ClientInfo {
+            name: "test-client".into(),
+            version: "1.0.0".into(),
+        };
+        let req = InitializeRequest::new(client_info.clone());
+        assert_eq!(req.protocol_version, "2024-11-05");
+        assert_eq!(req.clientInfo, client_info);
+    }
+
+    #[test]
+    fn test_initialize_response() {
+        let server_info = ServerInfo::new("phenotype", "0.1.0");
+        let resp = InitializeResponse::new(server_info.clone());
+        assert_eq!(resp.protocol_version, "2024-11-05");
+        assert_eq!(resp.serverInfo, server_info);
+    }
+
+    #[test]
+    fn test_server_capabilities_default() {
+        let caps = ServerCapabilities::default();
+        assert!(caps.tools.is_some());
+        assert!(caps.resources.is_some());
+        assert!(caps.prompts.is_some());
+    }
+
+    #[test]
+    fn test_server_capabilities_tools_only() {
+        let caps = ServerCapabilities::tools_only();
+        assert!(caps.tools.is_some());
+        assert!(caps.resources.is_none());
+        assert!(caps.prompts.is_none());
+    }
+
+    #[test]
+    fn test_tool_capability() {
+        let cap = ToolCapability::default();
+        assert!(cap.list_changed);
+    }
+
+    #[test]
+    fn test_resource_capability() {
+        let cap = ResourceCapability::default();
+        assert!(cap.subscribe);
+        assert!(cap.list_changed);
+    }
+
+    #[test]
+    fn test_prompt_capability() {
+        let cap = PromptCapability::default();
+        assert!(cap.list_changed);
+    }
+}

--- a/crates/phenotype-mcp/src/prompts.rs
+++ b/crates/phenotype-mcp/src/prompts.rs
@@ -1,0 +1,157 @@
+//! Prompt definitions for MCP protocol
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Prompt argument definition
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PromptArgument {
+    /// Argument name
+    pub name: String,
+    /// Human-readable argument description
+    pub description: String,
+    /// Whether the argument is required
+    #[serde(default)]
+    pub required: bool,
+}
+
+impl PromptArgument {
+    /// Create a new prompt argument
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            required: false,
+        }
+    }
+
+    /// Mark this argument as required
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+}
+
+/// Prompt message definition
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PromptMessage {
+    /// Message role ("user" or "assistant")
+    pub role: String,
+    /// Message content
+    pub content: Value,
+}
+
+impl PromptMessage {
+    /// Create a user message
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".into(),
+            content: Value::String(content.into()),
+        }
+    }
+
+    /// Create an assistant message
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".into(),
+            content: Value::String(content.into()),
+        }
+    }
+
+    /// Create a message with JSON content
+    pub fn with_json(role: impl Into<String>, content: Value) -> Self {
+        Self {
+            role: role.into(),
+            content,
+        }
+    }
+}
+
+/// Prompt definition
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Prompt {
+    /// Prompt name (unique identifier)
+    pub name: String,
+    /// Human-readable prompt description
+    pub description: String,
+    /// Prompt arguments/parameters
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<PromptArgument>,
+}
+
+impl Prompt {
+    /// Create a new prompt definition
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            arguments: Vec::new(),
+        }
+    }
+
+    /// Add an argument to the prompt
+    pub fn with_argument(mut self, arg: PromptArgument) -> Self {
+        self.arguments.push(arg);
+        self
+    }
+
+    /// Add a required argument to the prompt
+    pub fn with_required_arg(self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.with_argument(PromptArgument::new(name, description).required())
+    }
+
+    /// Add an optional argument to the prompt
+    pub fn with_optional_arg(self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.with_argument(PromptArgument::new(name, description))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prompt_argument() {
+        let arg = PromptArgument::new("context", "Additional context for the prompt");
+        assert_eq!(arg.name, "context");
+        assert!(!arg.required);
+
+        let required_arg = arg.required();
+        assert!(required_arg.required);
+    }
+
+    #[test]
+    fn test_prompt_message_user() {
+        let msg = PromptMessage::user("What should I do?");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content, Value::String("What should I do?".into()));
+    }
+
+    #[test]
+    fn test_prompt_message_assistant() {
+        let msg = PromptMessage::assistant("I can help you with that.");
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content, Value::String("I can help you with that.".into()));
+    }
+
+    #[test]
+    fn test_prompt_creation() {
+        let prompt = Prompt::new("code_review", "Code review assistant")
+            .with_required_arg("code", "Code to review")
+            .with_optional_arg("language", "Programming language");
+
+        assert_eq!(prompt.name, "code_review");
+        assert_eq!(prompt.arguments.len(), 2);
+        assert!(prompt.arguments[0].required);
+        assert!(!prompt.arguments[1].required);
+    }
+
+    #[test]
+    fn test_prompt_json_content() {
+        let content = serde_json::json!({"type": "object", "data": "example"});
+        let msg = PromptMessage::with_json("assistant", content.clone());
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content, content);
+    }
+}

--- a/crates/phenotype-mcp/src/resources.rs
+++ b/crates/phenotype-mcp/src/resources.rs
@@ -1,0 +1,161 @@
+//! Resource definitions for MCP protocol
+
+use serde::{Deserialize, Serialize};
+
+/// Resource content representation
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ResourceContents {
+    /// Text resource content
+    Text { text: String },
+    /// Binary resource content (base64 encoded)
+    Binary {
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+        data: String,
+    },
+}
+
+impl ResourceContents {
+    /// Create text content
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text {
+            text: text.into(),
+        }
+    }
+
+    /// Create binary content
+    pub fn binary(mime_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Binary {
+            mime_type: mime_type.into(),
+            data: data.into(),
+        }
+    }
+}
+
+/// Resource definition
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Resource {
+    /// Resource URI (unique identifier)
+    pub uri: String,
+    /// Human-readable resource name
+    pub name: String,
+    /// Human-readable resource description
+    pub description: String,
+    /// MIME type of the resource content
+    #[serde(rename = "mimeType")]
+    pub mime_type: String,
+}
+
+impl Resource {
+    /// Create a new resource definition
+    pub fn new(
+        uri: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        mime_type: impl Into<String>,
+    ) -> Self {
+        Self {
+            uri: uri.into(),
+            name: name.into(),
+            description: description.into(),
+            mime_type: mime_type.into(),
+        }
+    }
+
+    /// Create a text resource
+    pub fn text(
+        uri: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::new(uri, name, description, "text/plain")
+    }
+
+    /// Create a JSON resource
+    pub fn json(
+        uri: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::new(uri, name, description, "application/json")
+    }
+
+    /// Create a markdown resource
+    pub fn markdown(
+        uri: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::new(uri, name, description, "text/markdown")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resource_creation() {
+        let resource = Resource::new(
+            "file:///path/to/resource",
+            "My Resource",
+            "A test resource",
+            "text/plain",
+        );
+        assert_eq!(resource.uri, "file:///path/to/resource");
+        assert_eq!(resource.name, "My Resource");
+        assert_eq!(resource.mime_type, "text/plain");
+    }
+
+    #[test]
+    fn test_resource_text() {
+        let resource = Resource::text(
+            "file:///test.txt",
+            "Test File",
+            "A text file",
+        );
+        assert_eq!(resource.mime_type, "text/plain");
+    }
+
+    #[test]
+    fn test_resource_json() {
+        let resource = Resource::json(
+            "file:///test.json",
+            "Test JSON",
+            "A JSON file",
+        );
+        assert_eq!(resource.mime_type, "application/json");
+    }
+
+    #[test]
+    fn test_resource_markdown() {
+        let resource = Resource::markdown(
+            "file:///test.md",
+            "Test Markdown",
+            "A markdown file",
+        );
+        assert_eq!(resource.mime_type, "text/markdown");
+    }
+
+    #[test]
+    fn test_resource_contents_text() {
+        let contents = ResourceContents::text("Hello, world!");
+        match contents {
+            ResourceContents::Text { text } => assert_eq!(text, "Hello, world!"),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[test]
+    fn test_resource_contents_binary() {
+        let contents = ResourceContents::binary("image/png", "iVBORw0KGgo...");
+        match contents {
+            ResourceContents::Binary { mime_type, data } => {
+                assert_eq!(mime_type, "image/png");
+                assert_eq!(data, "iVBORw0KGgo...");
+            }
+            _ => panic!("Expected binary content"),
+        }
+    }
+}

--- a/crates/phenotype-mcp/src/tools.rs
+++ b/crates/phenotype-mcp/src/tools.rs
@@ -1,0 +1,294 @@
+//! Tool definitions and types for MCP protocol
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// JSON Schema definition for tool input parameters
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolInputSchema {
+    /// The type of the input (e.g., "object")
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Properties of the input object
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub properties: HashMap<String, Value>,
+    /// Required properties
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+    /// Additional schema attributes
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl ToolInputSchema {
+    /// Create a new tool input schema for an object type
+    pub fn object() -> Self {
+        Self {
+            type_: "object".into(),
+            properties: HashMap::new(),
+            required: Vec::new(),
+            extra: HashMap::new(),
+        }
+    }
+
+    /// Add a property to the schema
+    pub fn with_property(mut self, name: impl Into<String>, schema: Value) -> Self {
+        self.properties.insert(name.into(), schema);
+        self
+    }
+
+    /// Mark a property as required
+    pub fn require(mut self, name: impl Into<String>) -> Self {
+        self.required.push(name.into());
+        self
+    }
+}
+
+impl Default for ToolInputSchema {
+    fn default() -> Self {
+        Self::object()
+    }
+}
+
+/// Tool input containing arguments passed to the tool
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolInput {
+    /// The arguments passed to the tool
+    pub arguments: HashMap<String, Value>,
+}
+
+impl ToolInput {
+    /// Create new tool input
+    pub fn new(arguments: HashMap<String, Value>) -> Self {
+        Self { arguments }
+    }
+
+    /// Get a string argument
+    pub fn get_string(&self, key: &str) -> Option<String> {
+        self.arguments.get(key).and_then(|v| v.as_str().map(|s| s.to_string()))
+    }
+
+    /// Get an integer argument
+    pub fn get_i64(&self, key: &str) -> Option<i64> {
+        self.arguments.get(key).and_then(|v| v.as_i64())
+    }
+
+    /// Get a boolean argument
+    pub fn get_bool(&self, key: &str) -> Option<bool> {
+        self.arguments.get(key).and_then(|v| v.as_bool())
+    }
+
+    /// Get a raw JSON value argument
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.arguments.get(key)
+    }
+}
+
+impl Default for ToolInput {
+    fn default() -> Self {
+        Self {
+            arguments: HashMap::new(),
+        }
+    }
+}
+
+/// Tool result containing the output of a tool execution
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolResult {
+    /// Whether the tool succeeded
+    pub is_error: bool,
+    /// The result content (text or structured data)
+    pub content: Vec<ToolResultContent>,
+}
+
+impl ToolResult {
+    /// Create a successful tool result with text content
+    pub fn success(text: impl Into<String>) -> Self {
+        Self {
+            is_error: false,
+            content: vec![ToolResultContent::text(text)],
+        }
+    }
+
+    /// Create a successful tool result with structured JSON content
+    pub fn success_json(value: Value) -> Self {
+        Self {
+            is_error: false,
+            content: vec![ToolResultContent::Text {
+                text: value.to_string(),
+            }],
+        }
+    }
+
+    /// Create an error tool result
+    pub fn error(text: impl Into<String>) -> Self {
+        Self {
+            is_error: true,
+            content: vec![ToolResultContent::text(text)],
+        }
+    }
+
+    /// Add content to the result
+    pub fn with_content(mut self, content: ToolResultContent) -> Self {
+        self.content.push(content);
+        self
+    }
+}
+
+impl Default for ToolResult {
+    fn default() -> Self {
+        Self {
+            is_error: false,
+            content: Vec::new(),
+        }
+    }
+}
+
+/// Tool result content types
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ToolResultContent {
+    /// Text content
+    Text { text: String },
+    /// Image content (MIME type and base64 data)
+    Image {
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+        data: String,
+    },
+}
+
+impl ToolResultContent {
+    /// Create text content
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text {
+            text: text.into(),
+        }
+    }
+
+    /// Create image content
+    pub fn image(mime_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Image {
+            mime_type: mime_type.into(),
+            data: data.into(),
+        }
+    }
+}
+
+/// Tool definition
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Tool {
+    /// Tool name (unique identifier)
+    pub name: String,
+    /// Human-readable tool description
+    pub description: String,
+    /// JSON schema for the tool's input parameters
+    #[serde(rename = "inputSchema")]
+    pub input_schema: ToolInputSchema,
+}
+
+impl Tool {
+    /// Create a new tool definition
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            input_schema: ToolInputSchema::default(),
+        }
+    }
+
+    /// Set the input schema for the tool
+    pub fn with_schema(mut self, schema: ToolInputSchema) -> Self {
+        self.input_schema = schema;
+        self
+    }
+
+    /// Add a property to the input schema
+    pub fn with_property(mut self, name: impl Into<String>, schema: Value) -> Self {
+        self.input_schema = self
+            .input_schema
+            .with_property(name, schema);
+        self
+    }
+
+    /// Require a parameter in the input schema
+    pub fn require_param(mut self, name: impl Into<String>) -> Self {
+        self.input_schema = self.input_schema.require(name);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_creation() {
+        let tool = Tool::new("test_tool", "A test tool");
+        assert_eq!(tool.name, "test_tool");
+        assert_eq!(tool.description, "A test tool");
+    }
+
+    #[test]
+    fn test_tool_input_schema() {
+        let mut schema = ToolInputSchema::object();
+        schema.properties.insert(
+            "name".into(),
+            serde_json::json!({"type": "string"}),
+        );
+        schema.required.push("name".into());
+
+        assert_eq!(schema.type_, "object");
+        assert_eq!(schema.required.len(), 1);
+    }
+
+    #[test]
+    fn test_tool_input_getters() {
+        let mut args = HashMap::new();
+        args.insert("text".into(), Value::String("hello".into()));
+        args.insert("count".into(), Value::Number(42.into()));
+        args.insert("active".into(), Value::Bool(true));
+
+        let input = ToolInput::new(args);
+        assert_eq!(input.get_string("text"), Some("hello".into()));
+        assert_eq!(input.get_i64("count"), Some(42));
+        assert_eq!(input.get_bool("active"), Some(true));
+    }
+
+    #[test]
+    fn test_tool_result_success() {
+        let result = ToolResult::success("Operation completed");
+        assert!(!result.is_error);
+        assert_eq!(result.content.len(), 1);
+    }
+
+    #[test]
+    fn test_tool_result_error() {
+        let result = ToolResult::error("Something went wrong");
+        assert!(result.is_error);
+        assert_eq!(result.content.len(), 1);
+    }
+
+    #[test]
+    fn test_tool_result_content_text() {
+        let content = ToolResultContent::text("test content");
+        match content {
+            ToolResultContent::Text { text } => assert_eq!(text, "test content"),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[test]
+    fn test_tool_with_schema() {
+        let schema = ToolInputSchema::object()
+            .with_property("param1", serde_json::json!({"type": "string"}))
+            .require("param1");
+
+        let tool = Tool::new("my_tool", "A tool")
+            .with_schema(schema.clone())
+            .require_param("param2");
+
+        assert_eq!(tool.input_schema.required.len(), 2);
+    }
+}

--- a/crates/phenotype-retry/Cargo.toml
+++ b/crates/phenotype-retry/Cargo.toml
@@ -13,7 +13,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 
 [lib]
 path = "src/lib.rs"

--- a/modernization_worklog.md
+++ b/modernization_worklog.md
@@ -1,0 +1,52 @@
+# Modernization & Optimization Worklog - 2026-03-29
+
+## Context
+Goal: Improve overall User/Developer Experience (UX/DX) on macOS 26 and terminal. Forcible modernization and optimization via package swaps and modern tooling (ripgrep, fd, uv, bun, tsgo, etc.).
+
+## Audit Results (Current State)
+- **Shell**: Zsh (with `.zshrc` and `.zshrc.local`)
+- **Search**: `rg` installed at `/opt/homebrew/bin/rg`, `fd` at `/opt/homebrew/bin/fd`.
+- **Package Managers**: `uv`, `bun`, `brew`.
+- **Modern Replacements Found**:
+    - `ls` -> `eza` (aliased in `.zshrc.local`)
+    - `cat` -> `bat` (aliased in `.zshrc.local`)
+    - `cd` -> `zoxide` (initialized in `.zshrc.local`)
+    - `find` -> `fd` (suggested in `.zshrc.local` but commented out)
+    - `grep` -> `rg` (not aliased)
+    - `top` -> `btop` (installed, not aliased)
+    - `du` -> `dust` (installed, not aliased)
+    - `df` -> `duf` (installed, not aliased)
+    - `diff` -> `delta` (installed, usually configured via git)
+    - `fzf` installed and initialized.
+    - `yazi` (terminal file manager) installed.
+    - `atuin` (shell history) installed.
+- **Missing/New Targets**:
+    - `tsgo`: Found in npm as `@rslint/tsgo` (TypeScript 7 native compiler port). Extremely fast.
+    - `fastfetch`: Modern `neofetch` replacement.
+    - `bottom` (`btm`): Alternative to `btop`.
+    - `gping`: Ping with a graph.
+    - `doge`: Modern `dig` replacement (`dog`).
+    - `ouch`: Modern compression/decompression tool.
+    - `hx` (Helix): Modern editor (not found, though `nvim` is set as `FORGE_EDITOR`).
+
+## Proposed Actions
+
+### 1. Terminal UX/DX Improvements
+- [x] Implement `grep='rg'` and `find='fd'` aliases.
+- [x] Enable `FORGE_ENABLE_ZSH_RPROMPT_ASYNC=1` for better prompt performance.
+- [x] Install and configure `tsgo` for TypeScript projects.
+- [x] Install missing modern tools: `fastfetch`, `gping`, `ouch`, `doggo` (or `dog`), `bottom`.
+- [x] Configure `atuin` for better history management if not fully active.
+- [ ] Configure `yazi` as the default file manager.
+- [x] Setup `eza` and `bat` more aggressively.
+
+### 2. System Optimization
+- [x] Audit `Brewfile` to ensure all modern tools are tracked.
+- [x] Update `uv` and `bun` to latest versions.
+- [x] Replace standard `grep`/`find` in scripts where safe.
+
+## Progress Log
+- **2026-03-29**: Initial audit and worklog creation. Found `rg`, `fd`, `uv`, `bun` are already present but under-utilized.
+- **2026-03-29**: Updated `.zshrc.local` with aliases for `grep`, `find`, `top`, `du`, `df`, `ping`, `dig`, `neofetch`, `tsc`, `pip`, and `venv`.
+- **2026-03-29**: Updated `Brewfile` with modern 2026 tools and successfully ran `brew bundle`.
+- **2026-03-29**: Installed `tsgo` via npm.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
-//! Common error types for phenotype-infrakit.
+//! Error re-exports
 
-pub use phenotype_error_core::Error;
-
-pub type Result<T> = std::result::Result<T, Error>;
+pub use phenotype_errors::Error;
+pub use phenotype_errors::Result;


### PR DESCRIPTION
## Summary

Adds phenotype crates with various fixes and improvements.

## Changes

- Workspace dependency updates
- Various crate fixes and improvements

## Testing

- [ ] Tests pass
- [ ] Code review completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new crates/modules and changes the public `src/error.rs` re-export to `phenotype_errors`, which can break downstream compilation and error handling expectations. Most changes are additive, but API surface and workspace wiring (new crates not yet listed in `Cargo.toml` members/exclude) should be verified.
> 
> **Overview**
> Adds a new `phenotype-config` crate that standardizes multi-source config loading via `figment` (TOML/JSON/env) with a small builder API and error types.
> 
> Introduces MCP protocol data-model modules (`error`, `jsonrpc`, `messages`, `tools`, `resources`, `prompts`) to represent JSON-RPC/MCP requests, capabilities, and tool/resource/prompt schemas (currently additive alongside existing `phenotype-mcp` exports).
> 
> Updates `src/error.rs` to re-export `Error`/`Result` from `phenotype_errors` instead of `phenotype-error-core`, drops an unused `tokio` dev-dep in `phenotype-retry`, and adds Brewfile + `modernization_worklog.md` updates for macOS terminal tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff76767ff4943038e693d2ebb61e5eabdb12339c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->