### PR TITLE
feat(contracts): add in-memory adapter implementations and testing utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,3 @@ docs/worklogs/libification/WS6_RUST_TOML_AUDIT.md
 service_fixed.py
 service_working.py
 crates/phenotype-contracts/tests/
-crates/phenotype-http-client-core/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "crates/phenotype-health",
     "crates/phenotype-logging",
     "crates/phenotype-macros",
+    "crates/phenotype-mcp",
+    "crates/phenotype-http-client-core",
 ]
 
 [workspace.package]
@@ -70,6 +72,3 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
-
-# blake3 dependency
-generic-array = "0.14"

--- a/crates/agileplus-api-types/Cargo.toml
+++ b/crates/agileplus-api-types/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true

--- a/crates/agileplus-api-types/src/lib.rs
+++ b/crates/agileplus-api-types/src/lib.rs
@@ -1,18 +1,286 @@
 //! Shared API types for AgilePlus.
+//!
+//! Provides DTOs for API contracts, request/response types, and error handling.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
+// ============================================================================
+// Generic Response Wrapper
+// ============================================================================
+
+/// Generic API response envelope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiResponse<T> {
+    /// Response payload (if successful).
     pub data: Option<T>,
+    /// Error message (if failed).
     pub error: Option<String>,
 }
 
 impl<T> ApiResponse<T> {
+    /// Create a successful response.
     pub fn success(data: T) -> Self {
         Self {
             data: Some(data),
             error: None,
         }
+    }
+
+    /// Create an error response.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            data: None,
+            error: Some(message.into()),
+        }
+    }
+
+    /// Check if the response represents success.
+    pub fn is_success(&self) -> bool {
+        self.data.is_some() && self.error.is_none()
+    }
+}
+
+// ============================================================================
+// Pagination
+// ============================================================================
+
+/// Request parameters for paginated endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginationRequest {
+    /// Page number (1-indexed).
+    pub page: u32,
+    /// Items per page.
+    pub per_page: u32,
+}
+
+impl Default for PaginationRequest {
+    fn default() -> Self {
+        Self {
+            page: 1,
+            per_page: 20,
+        }
+    }
+}
+
+/// Paginated response metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginationMeta {
+    /// Current page number.
+    pub page: u32,
+    /// Items per page.
+    pub per_page: u32,
+    /// Total items available.
+    pub total: u64,
+    /// Total pages available.
+    pub total_pages: u32,
+}
+
+impl PaginationMeta {
+    /// Create pagination metadata.
+    pub fn new(page: u32, per_page: u32, total: u64) -> Self {
+        let total_pages = if total == 0 {
+            1
+        } else {
+            ((total + per_page as u64 - 1) / per_page as u64) as u32
+        };
+
+        Self {
+            page,
+            per_page,
+            total,
+            total_pages,
+        }
+    }
+}
+
+/// Generic paginated response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginatedResponse<T> {
+    /// Page data.
+    pub items: Vec<T>,
+    /// Pagination metadata.
+    pub pagination: PaginationMeta,
+}
+
+impl<T> PaginatedResponse<T> {
+    /// Create a paginated response.
+    pub fn new(items: Vec<T>, page: u32, per_page: u32, total: u64) -> Self {
+        Self {
+            items,
+            pagination: PaginationMeta::new(page, per_page, total),
+        }
+    }
+}
+
+// ============================================================================
+// Project DTOs
+// ============================================================================
+
+/// Request to create a new project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    pub description: String,
+}
+
+/// Response containing a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Work Item DTOs
+// ============================================================================
+
+/// Request to create a work item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateWorkItemRequest {
+    pub title: String,
+    pub description: String,
+    pub status: Option<String>,
+    pub priority: Option<String>,
+    pub assignee: Option<String>,
+}
+
+/// Request to update a work item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateWorkItemRequest {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub status: Option<String>,
+    pub priority: Option<String>,
+    pub assignee: Option<String>,
+}
+
+/// Response containing a work item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkItemResponse {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub title: String,
+    pub description: String,
+    pub status: String,
+    pub priority: String,
+    pub assignee: Option<String>,
+    pub parent_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Sprint DTOs
+// ============================================================================
+
+/// Request to create a sprint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateSprintRequest {
+    pub name: String,
+    pub goal: String,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+}
+
+/// Response containing a sprint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SprintResponse {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub name: String,
+    pub goal: String,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+}
+
+// ============================================================================
+// Error Response
+// ============================================================================
+
+/// Error response with code and message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub code: String,
+    pub message: String,
+}
+
+impl ErrorResponse {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_response_success() {
+        let resp: ApiResponse<String> = ApiResponse::success("test".into());
+        assert!(resp.is_success());
+        assert_eq!(resp.data, Some("test".into()));
+    }
+
+    #[test]
+    fn api_response_error() {
+        let resp: ApiResponse<String> = ApiResponse::error("failure");
+        assert!(!resp.is_success());
+        assert_eq!(resp.error, Some("failure".into()));
+    }
+
+    #[test]
+    fn pagination_meta() {
+        let meta = PaginationMeta::new(1, 20, 100);
+        assert_eq!(meta.total_pages, 5);
+        assert_eq!(meta.page, 1);
+    }
+
+    #[test]
+    fn pagination_meta_single_page() {
+        let meta = PaginationMeta::new(1, 50, 10);
+        assert_eq!(meta.total_pages, 1);
+    }
+
+    #[test]
+    fn pagination_meta_empty() {
+        let meta = PaginationMeta::new(1, 20, 0);
+        assert_eq!(meta.total_pages, 1);
+    }
+
+    #[test]
+    fn paginated_response() {
+        let items = vec![1, 2, 3];
+        let resp = PaginatedResponse::new(items.clone(), 1, 10, 3);
+        assert_eq!(resp.items, items);
+        assert_eq!(resp.pagination.total, 3);
+    }
+
+    #[test]
+    fn create_project_request() {
+        let req = CreateProjectRequest {
+            name: "Test".into(),
+            description: "A test".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("Test"));
+    }
+
+    #[test]
+    fn error_response() {
+        let err = ErrorResponse::new("NOT_FOUND", "Project not found");
+        assert_eq!(err.code, "NOT_FOUND");
+        assert_eq!(err.message, "Project not found");
     }
 }

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -9,6 +9,7 @@ description = "AgilePlus domain model — entities, value objects, and port inte
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 async-trait.workspace = true

--- a/crates/agileplus-domain/src/aggregates.rs
+++ b/crates/agileplus-domain/src/aggregates.rs
@@ -1,0 +1,301 @@
+//! Domain aggregates (aggregate roots) for AgilePlus.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::entities::{Project, WorkItem, Sprint};
+use crate::events::DomainEvent;
+use crate::values::{Priority, Status};
+
+/// A ProjectAggregate is the aggregate root containing a Project and all related work items.
+/// Changes to the project and its work items are tracked as domain events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectAggregate {
+    pub project: Project,
+    pub work_items: Vec<WorkItem>,
+    pub sprints: Vec<Sprint>,
+    pub events: Vec<DomainEvent>,
+}
+
+impl ProjectAggregate {
+    /// Create a new project aggregate.
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        let project = Project::new(name, description);
+
+        let now = Utc::now();
+        let event = DomainEvent::ProjectCreated {
+            project_id: project.id,
+            name: project.name.clone(),
+            description: project.description.clone(),
+            timestamp: now,
+        };
+
+        Self {
+            project,
+            work_items: Vec::new(),
+            sprints: Vec::new(),
+            events: vec![event],
+        }
+    }
+
+    /// Add a work item to the project.
+    pub fn add_work_item(
+        &mut self,
+        title: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Uuid {
+        let work_item = WorkItem::new(self.project.id, title, description);
+        let work_item_id = work_item.id;
+
+        let now = Utc::now();
+        self.events.push(DomainEvent::WorkItemCreated {
+            work_item_id,
+            project_id: self.project.id,
+            title: work_item.title.clone(),
+            description: work_item.description.clone(),
+            status: work_item.status.clone(),
+            priority: work_item.priority.clone(),
+            timestamp: now,
+        });
+
+        self.work_items.push(work_item);
+        work_item_id
+    }
+
+    /// Update the status of a work item.
+    pub fn update_work_item_status(&mut self, work_item_id: Uuid, new_status: Status) -> bool {
+        if let Some(work_item) = self.work_items.iter_mut().find(|w| w.id == work_item_id) {
+            let old_status = work_item.status.clone();
+            if old_status != new_status {
+                work_item.status = new_status.clone();
+                work_item.updated_at = Utc::now();
+
+                self.events.push(DomainEvent::WorkItemStatusChanged {
+                    work_item_id,
+                    old_status,
+                    new_status,
+                    timestamp: work_item.updated_at,
+                });
+
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Update the priority of a work item.
+    pub fn update_work_item_priority(&mut self, work_item_id: Uuid, new_priority: Priority) -> bool {
+        if let Some(work_item) = self.work_items.iter_mut().find(|w| w.id == work_item_id) {
+            let old_priority = work_item.priority.clone();
+            if old_priority != new_priority {
+                work_item.priority = new_priority.clone();
+                work_item.updated_at = Utc::now();
+
+                self.events.push(DomainEvent::WorkItemPriorityChanged {
+                    work_item_id,
+                    old_priority,
+                    new_priority,
+                    timestamp: work_item.updated_at,
+                });
+
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Assign a work item to a person.
+    pub fn assign_work_item(&mut self, work_item_id: Uuid, assignee: impl Into<String>) -> bool {
+        if let Some(work_item) = self.work_items.iter_mut().find(|w| w.id == work_item_id) {
+            let assignee_str = assignee.into();
+            work_item.assignee = Some(assignee_str.clone());
+            work_item.updated_at = Utc::now();
+
+            self.events.push(DomainEvent::WorkItemAssigned {
+                work_item_id,
+                assignee: assignee_str,
+                timestamp: work_item.updated_at,
+            });
+
+            return true;
+        }
+        false
+    }
+
+    /// Unassign a work item.
+    pub fn unassign_work_item(&mut self, work_item_id: Uuid) -> bool {
+        if let Some(work_item) = self.work_items.iter_mut().find(|w| w.id == work_item_id) {
+            if work_item.assignee.is_some() {
+                work_item.assignee = None;
+                work_item.updated_at = Utc::now();
+
+                self.events.push(DomainEvent::WorkItemUnassigned {
+                    work_item_id,
+                    timestamp: work_item.updated_at,
+                });
+
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Add a sprint to the project.
+    pub fn add_sprint(
+        &mut self,
+        name: impl Into<String>,
+        goal: impl Into<String>,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+    ) -> Uuid {
+        let sprint = Sprint {
+            id: Uuid::new_v4(),
+            project_id: self.project.id,
+            name: name.into(),
+            goal: goal.into(),
+            start_date,
+            end_date,
+        };
+
+        let sprint_id = sprint.id;
+        let now = Utc::now();
+
+        self.events.push(DomainEvent::SprintCreated {
+            sprint_id,
+            project_id: self.project.id,
+            name: sprint.name.clone(),
+            goal: sprint.goal.clone(),
+            start_date: sprint.start_date,
+            end_date: sprint.end_date,
+            timestamp: now,
+        });
+
+        self.sprints.push(sprint);
+        sprint_id
+    }
+
+    /// Get all uncommitted events.
+    pub fn events(&self) -> &[DomainEvent] {
+        &self.events
+    }
+
+    /// Clear all uncommitted events.
+    pub fn clear_events(&mut self) {
+        self.events.clear();
+    }
+
+    /// Get work item count.
+    pub fn work_item_count(&self) -> usize {
+        self.work_items.len()
+    }
+
+    /// Get sprint count.
+    pub fn sprint_count(&self) -> usize {
+        self.sprints.len()
+    }
+
+    /// Get work items in a specific status.
+    pub fn work_items_with_status(&self, status: &Status) -> Vec<&WorkItem> {
+        self.work_items.iter().filter(|w| &w.status == status).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_project_aggregate() {
+        let agg = ProjectAggregate::new("Test Project", "A test project");
+        assert_eq!(agg.work_item_count(), 0);
+        assert_eq!(agg.sprint_count(), 0);
+        assert_eq!(agg.events.len(), 1);
+    }
+
+    #[test]
+    fn add_work_item_to_aggregate() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let wi_id = agg.add_work_item("Task 1", "Do something");
+
+        assert_eq!(agg.work_item_count(), 1);
+        assert_eq!(agg.events.len(), 2);
+        assert!(!wi_id.is_nil());
+    }
+
+    #[test]
+    fn update_work_item_status() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let wi_id = agg.add_work_item("Task", "desc");
+
+        let result = agg.update_work_item_status(wi_id, Status::InProgress);
+        assert!(result);
+        assert_eq!(agg.events.len(), 3);
+
+        let work_item = agg.work_items.iter().find(|w| w.id == wi_id).unwrap();
+        assert_eq!(work_item.status, Status::InProgress);
+    }
+
+    #[test]
+    fn update_work_item_priority() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let wi_id = agg.add_work_item("Task", "desc");
+
+        let result = agg.update_work_item_priority(wi_id, Priority::High);
+        assert!(result);
+
+        let work_item = agg.work_items.iter().find(|w| w.id == wi_id).unwrap();
+        assert_eq!(work_item.priority, Priority::High);
+    }
+
+    #[test]
+    fn assign_and_unassign() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let wi_id = agg.add_work_item("Task", "desc");
+
+        assert!(agg.assign_work_item(wi_id, "alice@example.com"));
+        let work_item = agg.work_items.iter().find(|w| w.id == wi_id).unwrap();
+        assert_eq!(work_item.assignee.as_ref().unwrap(), "alice@example.com");
+
+        assert!(agg.unassign_work_item(wi_id));
+        let work_item = agg.work_items.iter().find(|w| w.id == wi_id).unwrap();
+        assert!(work_item.assignee.is_none());
+    }
+
+    #[test]
+    fn add_sprint() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let now = Utc::now();
+        let sprint_id = agg.add_sprint("Sprint 1", "Build feature X", now, now);
+
+        assert_eq!(agg.sprint_count(), 1);
+        assert!(!sprint_id.is_nil());
+    }
+
+    #[test]
+    fn work_items_with_status() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        let wi1 = agg.add_work_item("Task 1", "desc");
+        let _wi2 = agg.add_work_item("Task 2", "desc");
+
+        agg.update_work_item_status(wi1, Status::InProgress);
+
+        let in_progress = agg.work_items_with_status(&Status::InProgress);
+        assert_eq!(in_progress.len(), 1);
+
+        let backlog = agg.work_items_with_status(&Status::Backlog);
+        assert_eq!(backlog.len(), 1);
+    }
+
+    #[test]
+    fn events_are_recorded() {
+        let mut agg = ProjectAggregate::new("Test", "desc");
+        agg.add_work_item("Task", "desc");
+        agg.add_work_item("Task 2", "desc");
+
+        assert_eq!(agg.events.len(), 3); // 1 project + 2 work items
+
+        agg.clear_events();
+        assert_eq!(agg.events.len(), 0);
+    }
+}

--- a/crates/agileplus-domain/src/events.rs
+++ b/crates/agileplus-domain/src/events.rs
@@ -1,0 +1,188 @@
+//! Domain events for AgilePlus.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::values::{Priority, Status};
+
+/// A domain event representing a change in the system.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event_type")]
+pub enum DomainEvent {
+    /// A project was created.
+    #[serde(rename = "project_created")]
+    ProjectCreated {
+        project_id: Uuid,
+        name: String,
+        description: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A project was updated.
+    #[serde(rename = "project_updated")]
+    ProjectUpdated {
+        project_id: Uuid,
+        name: String,
+        description: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A work item was created.
+    #[serde(rename = "work_item_created")]
+    WorkItemCreated {
+        work_item_id: Uuid,
+        project_id: Uuid,
+        title: String,
+        description: String,
+        status: Status,
+        priority: Priority,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A work item status changed.
+    #[serde(rename = "work_item_status_changed")]
+    WorkItemStatusChanged {
+        work_item_id: Uuid,
+        old_status: Status,
+        new_status: Status,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A work item priority changed.
+    #[serde(rename = "work_item_priority_changed")]
+    WorkItemPriorityChanged {
+        work_item_id: Uuid,
+        old_priority: Priority,
+        new_priority: Priority,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A work item was assigned.
+    #[serde(rename = "work_item_assigned")]
+    WorkItemAssigned {
+        work_item_id: Uuid,
+        assignee: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A work item was unassigned.
+    #[serde(rename = "work_item_unassigned")]
+    WorkItemUnassigned {
+        work_item_id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A sprint was created.
+    #[serde(rename = "sprint_created")]
+    SprintCreated {
+        sprint_id: Uuid,
+        project_id: Uuid,
+        name: String,
+        goal: String,
+        start_date: DateTime<Utc>,
+        end_date: DateTime<Utc>,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A sprint was started.
+    #[serde(rename = "sprint_started")]
+    SprintStarted {
+        sprint_id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A sprint was completed.
+    #[serde(rename = "sprint_completed")]
+    SprintCompleted {
+        sprint_id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+}
+
+impl DomainEvent {
+    /// Get the timestamp of this event.
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        match self {
+            Self::ProjectCreated { timestamp, .. }
+            | Self::ProjectUpdated { timestamp, .. }
+            | Self::WorkItemCreated { timestamp, .. }
+            | Self::WorkItemStatusChanged { timestamp, .. }
+            | Self::WorkItemPriorityChanged { timestamp, .. }
+            | Self::WorkItemAssigned { timestamp, .. }
+            | Self::WorkItemUnassigned { timestamp, .. }
+            | Self::SprintCreated { timestamp, .. }
+            | Self::SprintStarted { timestamp, .. }
+            | Self::SprintCompleted { timestamp, .. } => *timestamp,
+        }
+    }
+
+    /// Get a human-readable event name.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::ProjectCreated { .. } => "ProjectCreated",
+            Self::ProjectUpdated { .. } => "ProjectUpdated",
+            Self::WorkItemCreated { .. } => "WorkItemCreated",
+            Self::WorkItemStatusChanged { .. } => "WorkItemStatusChanged",
+            Self::WorkItemPriorityChanged { .. } => "WorkItemPriorityChanged",
+            Self::WorkItemAssigned { .. } => "WorkItemAssigned",
+            Self::WorkItemUnassigned { .. } => "WorkItemUnassigned",
+            Self::SprintCreated { .. } => "SprintCreated",
+            Self::SprintStarted { .. } => "SprintStarted",
+            Self::SprintCompleted { .. } => "SprintCompleted",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_created_event() {
+        let event = DomainEvent::ProjectCreated {
+            project_id: Uuid::new_v4(),
+            name: "Test Project".into(),
+            description: "A test project".into(),
+            timestamp: Utc::now(),
+        };
+
+        assert_eq!(event.event_name(), "ProjectCreated");
+    }
+
+    #[test]
+    fn work_item_status_changed_event() {
+        let event = DomainEvent::WorkItemStatusChanged {
+            work_item_id: Uuid::new_v4(),
+            old_status: Status::Backlog,
+            new_status: Status::InProgress,
+            timestamp: Utc::now(),
+        };
+
+        assert_eq!(event.event_name(), "WorkItemStatusChanged");
+    }
+
+    #[test]
+    fn work_item_assigned_event() {
+        let event = DomainEvent::WorkItemAssigned {
+            work_item_id: Uuid::new_v4(),
+            assignee: "alice@example.com".into(),
+            timestamp: Utc::now(),
+        };
+
+        assert_eq!(event.event_name(), "WorkItemAssigned");
+    }
+
+    #[test]
+    fn events_serialize() {
+        let event = DomainEvent::ProjectCreated {
+            project_id: Uuid::new_v4(),
+            name: "Test".into(),
+            description: "desc".into(),
+            timestamp: Utc::now(),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("project_created"));
+    }
+}

--- a/crates/agileplus-domain/src/lib.rs
+++ b/crates/agileplus-domain/src/lib.rs
@@ -1,7 +1,14 @@
 //! # AgilePlus Domain
 //!
-//! Core domain model for AgilePlus: entities, value objects, and port interfaces.
+//! Core domain model for AgilePlus: entities, value objects, port interfaces, and aggregates.
 
+pub mod aggregates;
 pub mod entities;
+pub mod events;
 pub mod ports;
 pub mod values;
+
+pub use aggregates::ProjectAggregate;
+pub use entities::{Project, Sprint, WorkItem};
+pub use events::DomainEvent;
+pub use values::{Priority, Status};

--- a/crates/phenotype-contracts/src/adapters.rs
+++ b/crates/phenotype-contracts/src/adapters.rs
@@ -1,0 +1,334 @@
+//! Built-in adapter implementations for phenotype ports.
+//!
+//! Provides in-memory implementations suitable for testing and prototyping.
+
+use crate::error;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use uuid::Uuid;
+
+/// In-memory repository implementation using HashMap.
+///
+/// Thread-safe and suitable for testing. Not recommended for production use.
+pub struct InMemoryRepository<Id: Clone, Entity: Clone> {
+    store: Arc<RwLock<HashMap<Id, Entity>>>,
+}
+
+impl<Id: Clone + Eq + std::hash::Hash, Entity: Clone> InMemoryRepository<Id, Entity> {
+    /// Create a new in-memory repository.
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Create a pre-populated repository.
+    pub fn with_data(data: HashMap<Id, Entity>) -> Self {
+        Self {
+            store: Arc::new(RwLock::new(data)),
+        }
+    }
+
+    /// Get the number of items in the repository.
+    pub fn len(&self) -> usize {
+        self.store.read().unwrap().len()
+    }
+
+    /// Check if the repository is empty.
+    pub fn is_empty(&self) -> bool {
+        self.store.read().unwrap().is_empty()
+    }
+
+    /// Clear all items from the repository.
+    pub fn clear(&self) {
+        self.store.write().unwrap().clear();
+    }
+}
+
+impl<Id: Clone + Eq + std::hash::Hash + std::fmt::Debug, Entity: Clone> Default
+    for InMemoryRepository<Id, Entity>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Id: Clone + Eq + std::hash::Hash + std::fmt::Debug + Send + Sync, Entity: Clone + Send + Sync> crate::outbound::Repository
+    for InMemoryRepository<Id, Entity>
+{
+    type Entity = Entity;
+    type Id = Id;
+
+    fn save(&self, id: Self::Id, entity: Self::Entity) -> error::Result<()> {
+        self.store.write().unwrap().insert(id, entity);
+        Ok(())
+    }
+
+    fn get(&self, id: &Self::Id) -> error::Result<Self::Entity> {
+        self.store
+            .read()
+            .unwrap()
+            .get(id)
+            .cloned()
+            .ok_or_else(|| error::ErrorKind::not_found(format!("Entity not found: {:?}", id)))
+    }
+
+    fn delete(&self, id: &Self::Id) -> error::Result<()> {
+        self.store.write().unwrap().remove(id);
+        Ok(())
+    }
+
+    fn list(&self) -> error::Result<Vec<Self::Entity>> {
+        Ok(self.store.read().unwrap().values().cloned().collect())
+    }
+}
+
+/// In-memory cache implementation.
+///
+/// Thread-safe HashMap-backed cache.
+pub struct InMemoryCache<Key: Clone, Value: Clone> {
+    store: Arc<RwLock<HashMap<Key, Value>>>,
+}
+
+impl<Key: Clone + Eq + std::hash::Hash, Value: Clone> InMemoryCache<Key, Value> {
+    /// Create a new in-memory cache.
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Clear all entries from the cache.
+    pub fn clear(&self) {
+        self.store.write().unwrap().clear();
+    }
+
+    /// Get the number of cached entries.
+    pub fn len(&self) -> usize {
+        self.store.read().unwrap().len()
+    }
+
+    /// Check if the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.store.read().unwrap().is_empty()
+    }
+}
+
+impl<Key: Clone + Eq + std::hash::Hash, Value: Clone> Default
+    for InMemoryCache<Key, Value>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Key: Clone + Eq + std::hash::Hash + Send + Sync, Value: Clone + Send + Sync> crate::outbound::CachePort
+    for InMemoryCache<Key, Value>
+{
+    type Key = Key;
+    type Value = Value;
+
+    fn get(&self, key: &Self::Key) -> error::Result<Option<Self::Value>> {
+        Ok(self.store.read().unwrap().get(key).cloned())
+    }
+
+    fn set(&self, key: Self::Key, value: Self::Value) -> error::Result<()> {
+        self.store.write().unwrap().insert(key, value);
+        Ok(())
+    }
+
+    fn invalidate(&self, key: &Self::Key) -> error::Result<()> {
+        self.store.write().unwrap().remove(key);
+        Ok(())
+    }
+}
+
+/// In-memory event bus.
+///
+/// Collects events in memory. Suitable for testing.
+pub struct InMemoryEventBus<Event: Clone> {
+    events: Arc<RwLock<Vec<Event>>>,
+}
+
+impl<Event: Clone> InMemoryEventBus<Event> {
+    /// Create a new in-memory event bus.
+    pub fn new() -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Get all published events.
+    pub fn events(&self) -> Vec<Event> {
+        self.events.read().unwrap().clone()
+    }
+
+    /// Get the number of events published.
+    pub fn event_count(&self) -> usize {
+        self.events.read().unwrap().len()
+    }
+
+    /// Clear all events.
+    pub fn clear(&self) {
+        self.events.write().unwrap().clear();
+    }
+}
+
+impl<Event: Clone> Default for InMemoryEventBus<Event> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Event: Clone + Send + Sync> crate::outbound::EventBus for InMemoryEventBus<Event> {
+    type Event = Event;
+
+    fn publish(&self, event: Self::Event) -> error::Result<()> {
+        self.events.write().unwrap().push(event);
+        Ok(())
+    }
+
+    fn publish_batch(&self, events: Vec<Self::Event>) -> error::Result<()> {
+        self.events.write().unwrap().extend(events);
+        Ok(())
+    }
+}
+
+/// In-memory secret manager.
+///
+/// Stores secrets in plain HashMap. NOT FOR PRODUCTION.
+pub struct InMemorySecretManager {
+    secrets: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl InMemorySecretManager {
+    /// Create a new in-memory secret manager.
+    pub fn new() -> Self {
+        Self {
+            secrets: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Pre-load secrets.
+    pub fn with_secrets(secrets: HashMap<String, String>) -> Self {
+        Self {
+            secrets: Arc::new(RwLock::new(secrets)),
+        }
+    }
+
+    /// Clear all secrets.
+    pub fn clear(&self) {
+        self.secrets.write().unwrap().clear();
+    }
+}
+
+impl Default for InMemorySecretManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl crate::outbound::SecretManager for InMemorySecretManager {
+    fn get(&self, name: &str) -> error::Result<String> {
+        self.secrets
+            .read()
+            .unwrap()
+            .get(name)
+            .cloned()
+            .ok_or_else(|| error::ErrorKind::not_found(format!("Secret not found: {}", name)))
+    }
+
+    fn set(&self, name: String, value: String) -> error::Result<()> {
+        self.secrets.write().unwrap().insert(name, value);
+        Ok(())
+    }
+
+    fn delete(&self, name: &str) -> error::Result<()> {
+        self.secrets.write().unwrap().remove(name);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outbound::{CachePort, EventBus, Repository, SecretManager};
+
+    #[test]
+    fn in_memory_repository_operations() {
+        let repo: InMemoryRepository<String, String> = InMemoryRepository::new();
+        repo.save("key1".to_string(), "value1".to_string()).unwrap();
+
+        let value = repo.get(&"key1".to_string()).unwrap();
+        assert_eq!(value, "value1");
+
+        assert_eq!(repo.len(), 1);
+
+        repo.delete(&"key1".to_string()).unwrap();
+        assert!(repo.get(&"key1".to_string()).is_err());
+    }
+
+    #[test]
+    fn in_memory_repository_list() {
+        let repo: InMemoryRepository<String, i32> = InMemoryRepository::new();
+        repo.save("k1".to_string(), 1).unwrap();
+        repo.save("k2".to_string(), 2).unwrap();
+
+        let items = repo.list().unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn in_memory_repository_clear() {
+        let repo: InMemoryRepository<String, String> = InMemoryRepository::new();
+        repo.save("k1".to_string(), "v1".to_string()).unwrap();
+        assert_eq!(repo.len(), 1);
+
+        repo.clear();
+        assert!(repo.is_empty());
+    }
+
+    #[test]
+    fn in_memory_cache_operations() {
+        let cache: InMemoryCache<String, String> = InMemoryCache::new();
+        cache.set("key1".to_string(), "value1".to_string()).unwrap();
+
+        let value = cache.get(&"key1".to_string()).unwrap();
+        assert_eq!(value, Some("value1".to_string()));
+
+        cache.invalidate(&"key1".to_string()).unwrap();
+        let value = cache.get(&"key1".to_string()).unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn in_memory_event_bus() {
+        let bus: InMemoryEventBus<String> = InMemoryEventBus::new();
+        bus.publish("event1".to_string()).unwrap();
+        bus.publish("event2".to_string()).unwrap();
+
+        let events = bus.events();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn in_memory_event_bus_batch() {
+        let bus: InMemoryEventBus<String> = InMemoryEventBus::new();
+        bus.publish_batch(vec!["e1".to_string(), "e2".to_string()])
+            .unwrap();
+
+        assert_eq!(bus.event_count(), 2);
+    }
+
+    #[test]
+    fn in_memory_secret_manager() {
+        let manager = InMemorySecretManager::new();
+        manager.set("api_key".to_string(), "secret123".to_string()).unwrap();
+
+        let secret = manager.get("api_key").unwrap();
+        assert_eq!(secret, "secret123");
+
+        manager.delete("api_key").unwrap();
+        assert!(manager.get("api_key").is_err());
+    }
+}

--- a/crates/phenotype-contracts/src/lib.rs
+++ b/crates/phenotype-contracts/src/lib.rs
@@ -1,10 +1,14 @@
 //! Hexagonal architecture ports and domain model contracts for Phenotype.
 
+pub mod adapters;
 pub mod error;
 pub mod inbound;
 pub mod models;
 pub mod outbound;
 
+pub use adapters::{
+    InMemoryCache, InMemoryEventBus, InMemoryRepository, InMemorySecretManager,
+};
 pub use error::{ContractError, Result};
 pub use inbound::{CommandHandler, EventHandler, QueryHandler, UseCase};
 pub use models::{AggregateRoot, DomainEntity, DomainEvent, ValueObject};

--- a/crates/phenotype-http-client-core/Cargo.toml
+++ b/crates/phenotype-http-client-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "phenotype-http-client-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HTTP client core traits and retry logic for Phenotype"
+
+[dependencies]
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+async-trait.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/phenotype-http-client-core/src/auth.rs
+++ b/crates/phenotype-http-client-core/src/auth.rs
@@ -1,132 +1,88 @@
-//! HTTP authentication middleware.
-
-use http::{Request, Response, header::HeaderName, header::HeaderValue};
-use std::sync::Arc;
+//! HTTP authentication helpers.
 
 /// Authentication credentials.
 #[derive(Debug, Clone)]
 pub enum AuthCredentials {
-    /// Bearer token authentication.
     Bearer(String),
-    /// API key authentication.
-    ApiKey {
-        key: String,
-        value: String,
-        location: ApiKeyLocation,
-    },
-    /// Basic authentication.
+    ApiKey { header: String, value: String },
     Basic { username: String, password: String },
 }
 
-/// Where to place the API key.
-#[derive(Debug, Clone, Copy)]
-pub enum ApiKeyLocation {
-    /// In the Authorization header.
-    Authorization,
-    /// In a custom header.
-    Header(HeaderName),
-    /// As a query parameter.
-    QueryParam(String),
-}
-
 impl AuthCredentials {
-    /// Create bearer token credentials.
     pub fn bearer(token: impl Into<String>) -> Self {
         Self::Bearer(token.into())
     }
 
-    /// Create API key credentials.
-    pub fn api_key(key: impl Into<String>, value: impl Into<String>, location: ApiKeyLocation) -> Self {
+    pub fn api_key(header: impl Into<String>, value: impl Into<String>) -> Self {
         Self::ApiKey {
-            key: key.into(),
+            header: header.into(),
             value: value.into(),
-            location,
         }
     }
 
-    /// Create basic auth credentials.
     pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
         Self::Basic {
             username: username.into(),
             password: password.into(),
         }
     }
+
+    /// Return the header name and value for this credential.
+    pub fn to_header(&self) -> (String, String) {
+        match self {
+            Self::Bearer(token) => ("Authorization".to_string(), format!("Bearer {token}")),
+            Self::ApiKey { header, value } => (header.clone(), value.clone()),
+            Self::Basic { username, password } => {
+                use std::io::Write;
+                let mut buf = Vec::new();
+                write!(buf, "{username}:{password}").unwrap();
+                let encoded = base64_encode(&buf);
+                ("Authorization".to_string(), format!("Basic {encoded}"))
+            }
+        }
+    }
 }
 
-/// Authentication middleware.
+/// Auth middleware that holds credentials.
 #[derive(Debug, Clone)]
 pub struct AuthMiddleware {
-    credentials: Arc<AuthCredentials>,
+    credentials: AuthCredentials,
 }
 
 impl AuthMiddleware {
-    /// Create new auth middleware.
     pub fn new(credentials: AuthCredentials) -> Self {
-        Self {
-            credentials: Arc::new(credentials),
-        }
+        Self { credentials }
     }
 
-    /// Apply authentication to a request.
-    pub fn apply<B>(&self, mut request: Request<B>) -> Result<Response<Vec<u8>>, crate::error::TransportError> {
-        match self.credentials.as_ref() {
-            AuthCredentials::Bearer(token) => {
-                let header_value = HeaderValue::from_str(&format!("Bearer {}", token))
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid bearer token: {}", e)))?;
-                request.headers_mut().insert(header::AUTHORIZATION, header_value);
-            }
-            AuthCredentials::ApiKey { key, value, location } => {
-                let header_name = match location {
-                    ApiKeyLocation::Authorization => header::AUTHORIZATION,
-                    ApiKeyLocation::Header(name) => *name,
-                    ApiKeyLocation::QueryParam(_) => {
-                        return Err(crate::error::TransportError::Auth(
-                            "Query param auth not supported in middleware".into(),
-                        ));
-                    }
-                };
-
-                let header_value = HeaderValue::from_str(&value)
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid API key: {}", e)))?;
-                request.headers_mut().insert(header_name, header_value);
-            }
-            AuthCredentials::Basic { username, password } => {
-                let credentials = base64::Engine::encode(
-                    &base64::engine::general_purpose::STANDARD,
-                    format!("{}:{}", username, password),
-                );
-                let header_value = HeaderValue::from_str(&format!("Basic {}", credentials))
-                    .map_err(|e| crate::error::TransportError::Auth(format!("Invalid basic auth: {}", e)))?;
-                request.headers_mut().insert(header::AUTHORIZATION, header_value);
-            }
-        }
-
-        Ok(Response::new(Vec::new()))
+    /// Get the auth header pair.
+    pub fn header(&self) -> (String, String) {
+        self.credentials.to_header()
     }
 }
 
-/// Convenience extension trait for adding auth to requests.
-pub trait RequestAuthExt {
-    /// Add bearer authentication.
-    fn bearer_auth(self, token: impl Into<String>) -> Self;
-
-    /// Add API key authentication.
-    fn api_key_auth(self, key: impl Into<String>, value: impl Into<String>) -> Self;
-}
-
-impl<B> RequestAuthExt for Request<B> {
-    fn bearer_auth(mut self, token: impl Into<String>) -> Self {
-        let header_value = HeaderValue::from_str(&format!("Bearer {}", token.into())).unwrap();
-        self.headers_mut().insert(header::AUTHORIZATION, header_value);
-        self
+/// Simple base64 encoding (no external dep).
+fn base64_encode(input: &[u8]) -> String {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::new();
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let triple = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        result.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(triple & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
     }
-
-    fn api_key_auth(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        let header_name = HeaderName::from_bytes(key.into().as_bytes()).unwrap();
-        let header_value = HeaderValue::from_str(&value.into()).unwrap();
-        self.headers_mut().insert(header_name, header_value);
-        self
-    }
+    result
 }
 
 #[cfg(test)]
@@ -134,24 +90,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bearer_auth() {
-        let creds = AuthCredentials::bearer("my-token");
-        match creds {
-            AuthCredentials::Bearer(token) => assert_eq!(token, "my-token"),
-            _ => panic!("Expected Bearer variant"),
-        }
+    fn bearer_header() {
+        let creds = AuthCredentials::bearer("tok123");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "Authorization");
+        assert_eq!(value, "Bearer tok123");
     }
 
     #[test]
-    fn test_api_key_auth() {
-        let creds = AuthCredentials::api_key("X-API-Key", "secret-key", ApiKeyLocation::Authorization);
-        match creds {
-            AuthCredentials::ApiKey { key, value, location } => {
-                assert_eq!(key, "X-API-Key");
-                assert_eq!(value, "secret-key");
-                matches!(location, ApiKeyLocation::Authorization);
-            }
-            _ => panic!("Expected ApiKey variant"),
-        }
+    fn api_key_header() {
+        let creds = AuthCredentials::api_key("X-API-Key", "secret");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "X-API-Key");
+        assert_eq!(value, "secret");
+    }
+
+    #[test]
+    fn basic_header() {
+        let creds = AuthCredentials::basic("user", "pass");
+        let (name, value) = creds.to_header();
+        assert_eq!(name, "Authorization");
+        assert!(value.starts_with("Basic "));
+    }
+
+    #[test]
+    fn base64_encode_hello() {
+        assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
     }
 }

--- a/crates/phenotype-http-client-core/src/error.rs
+++ b/crates/phenotype-http-client-core/src/error.rs
@@ -23,20 +23,8 @@ pub enum TransportError {
     #[error("server error: {status} - {message}")]
     Server { status: u16, message: String },
 
-    #[error("parse error: {0}")]
-    Parse(String),
-
-    #[error("validation error: {0}")]
-    Validation(String),
-
     #[error("not found: {0}")]
     NotFound(String),
-
-    #[error("forbidden: {0}")]
-    Forbidden(String),
-
-    #[error("conflict: {0}")]
-    Conflict(String),
 
     #[error("serialization error: {0}")]
     Serialization(String),
@@ -46,15 +34,6 @@ pub enum TransportError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-
-    #[error("http error: {0}")]
-    Http(#[from] http::Error),
-
-    #[error("url error: {0}")]
-    Url(#[from] url::ParseError),
-
-    #[error("reqwest error: {0}")]
-    Reqwest(#[from] reqwest::Error),
 }
 
 impl TransportError {
@@ -78,22 +57,15 @@ impl TransportError {
             TransportError::Authentication(_) => ErrorKind::Authentication,
             TransportError::RateLimited { .. } => ErrorKind::RateLimited,
             TransportError::Server { .. } => ErrorKind::Server,
-            TransportError::Parse(_) => ErrorKind::Parse,
-            TransportError::Validation(_) => ErrorKind::Validation,
             TransportError::NotFound(_) => ErrorKind::NotFound,
-            TransportError::Forbidden(_) => ErrorKind::Forbidden,
-            TransportError::Conflict(_) => ErrorKind::Conflict,
             TransportError::Serialization(_) => ErrorKind::Serialization,
             TransportError::Unknown(_) => ErrorKind::Unknown,
             TransportError::Io(_) => ErrorKind::Io,
-            TransportError::Http(_) => ErrorKind::Http,
-            TransportError::Url(_) => ErrorKind::Url,
-            TransportError::Reqwest(_) => ErrorKind::Reqwest,
         }
     }
 }
 
-/// Error kind categorization for transport errors.
+/// Error kind categorization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorKind {
     Request,
@@ -102,15 +74,8 @@ pub enum ErrorKind {
     Authentication,
     RateLimited,
     Server,
-    Parse,
-    Validation,
     NotFound,
-    Forbidden,
-    Conflict,
     Serialization,
     Unknown,
     Io,
-    Http,
-    Url,
-    Reqwest,
 }

--- a/crates/phenotype-http-client-core/src/lib.rs
+++ b/crates/phenotype-http-client-core/src/lib.rs
@@ -1,129 +1,45 @@
 //! # HTTP Client Core
 //!
-//! Core traits and utilities for HTTP clients in the Phenotype ecosystem.
-//!
-//! ## Features
-//!
-//! - `HttpTransport` - Core transport trait for HTTP clients
-//! - `RetryPolicy` - Retry logic with backoff
-//! - `TransportError` - Unified error types
-//! - `AuthMiddleware` - Authentication middleware support
-//!
-//! ## Usage
-//!
-//! ```rust,ignore
-//! use phenotype_http_client_core::{HttpTransport, RetryPolicy, TransportError};
-//!
-//! struct MyClient {
-//!     base_url: url::Url,
-//!     inner: reqwest::Client,
-//! }
-//!
-//! #[async_trait::async_trait]
-//! impl HttpTransport for MyClient {
-//!     async fn request(&self, req: http::Request<Vec<u8>>) -> Result<http::Response<Vec<u8>>, TransportError> {
-//!         // implementation
-//!     }
-//! }
-//! ```
+//! Core traits and retry logic for HTTP clients in the Phenotype ecosystem.
+//! Minimal, no external HTTP crate dependency — consumers bring their own (reqwest, hyper, etc).
 
+pub mod auth;
 pub mod error;
 pub mod retry;
-pub mod transport;
-pub mod auth;
 
-pub use error::{TransportError, ErrorKind};
-pub use retry::{RetryPolicy, Backoff};
-pub use transport::HttpTransport;
-pub use auth::{AuthMiddleware, BearerToken};
-
-use thiserror::Error;
+pub use auth::{AuthCredentials, AuthMiddleware};
+pub use error::{ErrorKind, TransportError};
+pub use retry::RetryPolicy;
 
 /// Result type for HTTP transport operations.
 pub type Result<T> = std::result::Result<T, TransportError>;
 
-/// Extension trait for adding retry logic to transports.
-pub trait RetryExt: HttpTransport {
-    /// Wrap this transport with retry logic.
-    fn with_retry(self, policy: RetryPolicy) -> RetryTransport<Self>
-    where
-        Self: Sized,
-    {
-        RetryTransport {
-            inner: self,
-            policy,
-        }
-    }
-
-    /// Wrap this transport with authentication.
-    fn with_auth(self, auth: AuthMiddleware) -> AuthTransport<Self>
-    where
-        Self: Sized,
-    {
-        AuthTransport {
-            inner: self,
-            auth,
-        }
-    }
-}
-
-impl<T: HttpTransport> RetryExt for T {}
-
-/// Transport wrapper that adds retry logic.
-#[derive(Debug, Clone)]
-pub struct RetryTransport<T> {
-    inner: T,
-    policy: RetryPolicy,
-}
-
+/// Core HTTP transport trait. Implementors wrap their preferred HTTP client.
 #[async_trait::async_trait]
-impl<T: HttpTransport> HttpTransport for RetryTransport<T> {
-    async fn request(
+pub trait HttpTransport: Send + Sync {
+    async fn execute(
         &self,
-        req: http::Request<Vec<u8>>,
-    ) -> Result<http::Response<Vec<u8>>> {
-        let mut attempt = 0;
-        let mut last_error = None;
-
-        loop {
-            match self.inner.request(req.clone()).await {
-                Ok(response) => return Ok(response),
-                Err(e) => {
-                    attempt += 1;
-                    last_error = Some(e);
-
-                    if attempt >= self.policy.max_attempts {
-                        break;
-                    }
-
-                    if !self.policy.should_retry(&e) {
-                        break;
-                    }
-
-                    let delay = self.policy.backoff.calculate(attempt);
-                    tokio::time::sleep(delay).await;
-                }
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| TransportError::Unknown("No error".into())))
-    }
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: Option<&[u8]>,
+    ) -> Result<HttpResponse>;
 }
 
-/// Transport wrapper that adds authentication.
+/// Simplified HTTP response.
 #[derive(Debug, Clone)]
-pub struct AuthTransport<T> {
-    inner: T,
-    auth: AuthMiddleware,
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
 }
 
-#[async_trait::async_trait]
-impl<T: HttpTransport> HttpTransport for AuthTransport<T> {
-    async fn request(
-        &self,
-        mut req: http::Request<Vec<u8>>,
-    ) -> Result<http::Response<Vec<u8>>> {
-        self.auth.apply(&mut req);
-        self.inner.request(req).await
+impl HttpResponse {
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    pub fn body_as_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.body)
     }
 }

--- a/crates/phenotype-http-client-core/src/retry.rs
+++ b/crates/phenotype-http-client-core/src/retry.rs
@@ -1,86 +1,45 @@
 //! HTTP retry policy with exponential backoff.
 
-use std::time::Duration;
 use crate::error::TransportError;
+use std::time::Duration;
 
 /// Retry policy configuration.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
-    /// Maximum number of retries.
-    pub max_retries: u32,
-    /// Initial delay between retries.
+    pub max_attempts: u32,
     pub initial_delay: Duration,
-    /// Maximum delay between retries.
     pub max_delay: Duration,
-    /// Multiplier for exponential backoff.
     pub backoff_multiplier: f64,
-    /// Jitter factor (0.0 to 1.0).
-    pub jitter: f64,
 }
 
 impl Default for RetryPolicy {
     fn default() -> Self {
         Self {
-            max_retries: 3,
+            max_attempts: 3,
             initial_delay: Duration::from_millis(100),
             max_delay: Duration::from_secs(30),
             backoff_multiplier: 2.0,
-            jitter: 0.1,
         }
     }
 }
 
 impl RetryPolicy {
-    /// Create a new retry policy with custom configuration.
-    pub fn new(
-        max_retries: u32,
-        initial_delay: Duration,
-        max_delay: Duration,
-        backoff_multiplier: f64,
-        jitter: f64,
-    ) -> Self {
-        Self {
-            max_retries,
-            initial_delay,
-            max_delay,
-            backoff_multiplier,
-            jitter,
-        }
-    }
-
-    /// Calculate the delay for the given attempt number.
+    /// Calculate the delay for the given attempt number (0-indexed).
     pub fn delay_for(&self, attempt: u32) -> Duration {
-        let base_delay = self.initial_delay * self.backoff_multiplier.powi(attempt as i32 - 1);
-        let capped_delay = base_delay.min(self.max_delay);
-
-        // Add jitter
-        let jitter_range = capped_delay.mul_f64(self.jitter);
-        let jitter_ns = (rand_ratio() * jitter_range.as_nanos() as f64) as u64;
-
-        capped_delay + Duration::from_nanos(jitter_ns)
+        let base = self.initial_delay.mul_f64(self.backoff_multiplier.powi(attempt as i32));
+        base.min(self.max_delay)
     }
 
-    /// Check if we should retry the given error.
+    /// Check if we should retry the given error at the given attempt.
     pub fn should_retry(&self, error: &TransportError, attempt: u32) -> bool {
-        if attempt >= self.max_retries {
+        if attempt >= self.max_attempts {
             return false;
         }
-
         error.is_retryable()
     }
 }
 
-/// Simple pseudo-random number generator for jitter.
-fn rand_ratio() -> f64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .subsec_nanos();
-    (nanos % 1000) as f64 / 1000.0
-}
-
-/// Retry future with policy.
+/// Execute a closure with retry logic.
 pub async fn retry_with_policy<F, Fut, T>(
     policy: &RetryPolicy,
     mut f: F,
@@ -90,7 +49,6 @@ where
     Fut: std::future::Future<Output = Result<T, TransportError>>,
 {
     let mut attempt = 0u32;
-
     loop {
         match f().await {
             Ok(result) => return Ok(result),
@@ -98,9 +56,8 @@ where
                 if !policy.should_retry(&error, attempt) {
                     return Err(error);
                 }
-
                 let delay = policy.delay_for(attempt);
-                tracing::debug!("retry attempt {} after {:?}: {}", attempt, delay, error);
+                tracing::debug!(attempt, ?delay, %error, "retrying request");
                 tokio::time::sleep(delay).await;
                 attempt += 1;
             }
@@ -113,43 +70,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_retry_policy_default() {
+    fn default_policy() {
         let policy = RetryPolicy::default();
-        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.max_attempts, 3);
     }
 
     #[test]
-    fn test_delay_calculation() {
-        let policy = RetryPolicy::new(3, Duration::from_millis(100), Duration::from_secs(30), 2.0, 0.0);
-
-        // Attempt 0: 100ms
-        let delay0 = policy.delay_for(0);
-        assert_eq!(delay0, Duration::from_millis(100));
-
-        // Attempt 1: 200ms
-        let delay1 = policy.delay_for(1);
-        assert_eq!(delay1, Duration::from_millis(200));
-
-        // Attempt 2: 400ms
-        let delay2 = policy.delay_for(2);
-        assert_eq!(delay2, Duration::from_millis(400));
+    fn delay_calculation() {
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(30),
+            backoff_multiplier: 2.0,
+        };
+        assert_eq!(policy.delay_for(0), Duration::from_millis(100));
+        assert_eq!(policy.delay_for(1), Duration::from_millis(200));
+        assert_eq!(policy.delay_for(2), Duration::from_millis(400));
     }
 
     #[test]
-    fn test_should_retry() {
+    fn should_retry_retryable() {
         let policy = RetryPolicy::default();
+        let err = TransportError::Timeout("timeout".into());
+        assert!(policy.should_retry(&err, 0));
+        assert!(!policy.should_retry(&err, 3));
+    }
 
-        // Timeout is retryable
-        let timeout = TransportError::Timeout("timeout".into());
-        assert!(policy.should_retry(&timeout, 0));
-        assert!(policy.should_retry(&timeout, 1));
-        assert!(policy.should_retry(&timeout, 2));
-
-        // But not after max retries
-        assert!(!policy.should_retry(&timeout, 3));
-
-        // Validation error is not retryable
-        let validation = TransportError::Validation("invalid".into());
-        assert!(!policy.should_retry(&validation, 0));
+    #[test]
+    fn should_not_retry_non_retryable() {
+        let policy = RetryPolicy::default();
+        let err = TransportError::NotFound("missing".into());
+        assert!(!policy.should_retry(&err, 0));
     }
 }

--- a/crates/phenotype-mcp/Cargo.toml
+++ b/crates/phenotype-mcp/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "phenotype-mcp"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-description = "MCP server for Phenotype"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "MCP (Model Context Protocol) server types for Phenotype"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-fastmcp = "3"
+serde.workspace = true
+serde_json.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/phenotype-mcp/src/lib.rs
+++ b/crates/phenotype-mcp/src/lib.rs
@@ -1,21 +1,65 @@
-//! Phenotype MCP Server
+//! # Phenotype MCP
 //!
-//! MCP (Model Context Protocol) server for Phenotype tools.
+//! MCP (Model Context Protocol) types and tool definitions for Phenotype.
+//! Provides the data structures for registering tools, resources, and prompts.
 
 pub mod tools;
 
-use fastmcp::{Server, Tool, ToolInput, ToolResult};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-/// MCP Server configuration
+/// MCP tool definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Config {
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+/// MCP tool result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub content: Vec<ContentBlock>,
+    pub is_error: bool,
+}
+
+/// Content block in a tool result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { data: String, mime_type: String },
+}
+
+impl ToolResult {
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: vec![ContentBlock::Text {
+                text: content.into(),
+            }],
+            is_error: false,
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            content: vec![ContentBlock::Text {
+                text: message.into(),
+            }],
+            is_error: true,
+        }
+    }
+}
+
+/// MCP server configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
     pub name: String,
     pub version: String,
 }
 
-impl Default for Config {
+impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             name: "phenotype".into(),
@@ -24,92 +68,28 @@ impl Default for Config {
     }
 }
 
-/// Create the Phenotype MCP server
-pub fn create_server(config: Config) -> Server {
-    let mut server = Server::new(&config.name);
-    
-    // Register AgilePlus tools
-    server.add_tool(Tool::new(
-        "agileplus_create_feature",
-        "Create a feature specification",
-        |input: ToolInput| {
-            let title = input.arguments.get("title")
-                .and_then(|v| v.as_str())
-                .unwrap_or("Untitled");
-            ToolResult::success(serde_json::json!({
-                "feature_id": format!("feat_{}", uuid::Uuid::new_v4()),
-                "title": title,
-                "status": "created"
-            }))
-        },
-    ));
-    
-    server.add_tool(Tool::new(
-        "agileplus_validate",
-        "Validate a feature against governance rules",
-        |input: ToolInput| {
-            let feature_id = input.arguments.get("feature_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            ToolResult::success(serde_json::json!({
-                "valid": true,
-                "feature_id": feature_id,
-                "checks_passed": 5,
-                "checks_total": 5
-            }))
-        },
-    ));
-    
-    server.add_tool(Tool::new(
-        "agileplus_status",
-        "Update work package status",
-        |input: ToolInput| {
-            let wp_id = input.arguments.get("wp_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            let state = input.arguments.get("state")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            ToolResult::success(serde_json::json!({
-                "wp_id": wp_id,
-                "state": state,
-                "updated": true
-            }))
-        },
-    ));
-    
-    // Register Phenotype tools
-    server.add_tool(Tool::new(
-        "phenotype_parse_spec",
-        "Parse and validate specifications",
-        |input: ToolInput| {
-            let content = input.arguments.get("spec_content")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            ToolResult::success(serde_json::json!({
-                "valid": true,
-                "lines": content.lines().count()
-            }))
-        },
-    ));
-    
-    // Register Agent tools
-    server.add_tool(Tool::new(
-        "agent_dispatch",
-        "Dispatch a task to an AI agent",
-        |input: ToolInput| {
-            let task = input.arguments.get("task")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            ToolResult::success(serde_json::json!({
-                "task_id": format!("task_{}", uuid::Uuid::new_v4()),
-                "task": task,
-                "status": "dispatched"
-            }))
-        },
-    ));
-    
-    server
+/// Registry of available MCP tools.
+#[derive(Debug, Default)]
+pub struct ToolRegistry {
+    tools: Vec<ToolDef>,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, tool: ToolDef) {
+        self.tools.push(tool);
+    }
+
+    pub fn list(&self) -> &[ToolDef] {
+        &self.tools
+    }
+
+    pub fn find(&self, name: &str) -> Option<&ToolDef> {
+        self.tools.iter().find(|t| t.name == name)
+    }
 }
 
 #[cfg(test)]
@@ -117,8 +97,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_server_creation() {
-        let server = create_server(Config::default());
-        assert_eq!(server.name(), "phenotype");
+    fn tool_result_text() {
+        let r = ToolResult::text("hello");
+        assert!(!r.is_error);
+        assert_eq!(r.content.len(), 1);
+    }
+
+    #[test]
+    fn tool_result_error() {
+        let r = ToolResult::error("oops");
+        assert!(r.is_error);
+    }
+
+    #[test]
+    fn tool_registry() {
+        let mut reg = ToolRegistry::new();
+        reg.register(ToolDef {
+            name: "test_tool".into(),
+            description: "A test tool".into(),
+            input_schema: serde_json::json!({}),
+        });
+        assert_eq!(reg.list().len(), 1);
+        assert!(reg.find("test_tool").is_some());
+        assert!(reg.find("missing").is_none());
     }
 }

--- a/crates/phenotype-mcp/src/tools/mod.rs
+++ b/crates/phenotype-mcp/src/tools/mod.rs
@@ -1,1 +1,19 @@
-//! Tools module
+//! Built-in MCP tool definitions for Phenotype.
+
+use crate::ToolDef;
+
+/// Create the default set of Phenotype MCP tools.
+pub fn default_tools() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: "phenotype_version".into(),
+            description: "Get the current Phenotype version".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+        },
+        ToolDef {
+            name: "phenotype_status".into(),
+            description: "Get workspace health status".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+        },
+    ]
+}

--- a/crates/phenotype-telemetry/Cargo.toml
+++ b/crates/phenotype-telemetry/Cargo.toml
@@ -10,4 +10,11 @@ description = "Phenotype Telemetry"
 path = "src/lib.rs"
 
 [dependencies]
-phenotype-error-core = { version = "0.1.0", path = "../phenotype-error-core" }
+serde.workspace = true
+serde_json.workspace = true
+dashmap.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/phenotype-telemetry/src/registry.rs
+++ b/crates/phenotype-telemetry/src/registry.rs
@@ -1,0 +1,241 @@
+//! Metrics registry for collecting and storing telemetry data.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+/// Telemetry service configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    pub service_name: String,
+    pub environment: String,
+}
+
+/// Metric types supported by the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Metric {
+    #[serde(rename = "counter")]
+    Counter { value: u64 },
+    #[serde(rename = "gauge")]
+    Gauge { value: f64 },
+    #[serde(rename = "histogram")]
+    Histogram { values: Vec<f64> },
+}
+
+/// Counter metric — incremental counter.
+#[derive(Debug, Clone)]
+pub struct Counter {
+    name: String,
+    value: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl Counter {
+    /// Increment the counter by 1.
+    pub fn inc(&self) {
+        self.value.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Increment the counter by `delta`.
+    pub fn add(&self, delta: u64) {
+        self.value.fetch_add(delta, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Get the current value.
+    pub fn value(&self) -> u64 {
+        self.value.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Gauge metric — point-in-time measurement.
+#[derive(Debug, Clone)]
+pub struct Gauge {
+    name: String,
+    value: Arc<std::sync::Mutex<f64>>,
+}
+
+impl Gauge {
+    /// Set the gauge to a specific value.
+    pub fn set(&self, value: f64) {
+        *self.value.lock().unwrap() = value;
+    }
+
+    /// Get the current value.
+    pub fn value(&self) -> f64 {
+        *self.value.lock().unwrap()
+    }
+}
+
+/// Histogram metric — distribution of values.
+#[derive(Debug, Clone)]
+pub struct Histogram {
+    name: String,
+    values: Arc<std::sync::Mutex<Vec<f64>>>,
+}
+
+impl Histogram {
+    /// Record a value in the histogram.
+    pub fn observe(&self, value: f64) {
+        self.values.lock().unwrap().push(value);
+    }
+
+    /// Get all recorded values.
+    pub fn values(&self) -> Vec<f64> {
+        self.values.lock().unwrap().clone()
+    }
+}
+
+/// Metrics registry for centralized metric management.
+#[derive(Debug)]
+pub struct MetricsRegistry {
+    config: TelemetryConfig,
+    counters: DashMap<String, Counter>,
+    gauges: DashMap<String, Gauge>,
+    histograms: DashMap<String, Histogram>,
+}
+
+impl MetricsRegistry {
+    /// Create a new metrics registry.
+    pub fn new(config: TelemetryConfig) -> Self {
+        Self {
+            config,
+            counters: DashMap::new(),
+            gauges: DashMap::new(),
+            histograms: DashMap::new(),
+        }
+    }
+
+    /// Get or create a counter.
+    pub fn counter(&self, name: impl Into<String>) -> Counter {
+        let name = name.into();
+        self.counters
+            .entry(name.clone())
+            .or_insert_with(|| Counter {
+                name: name.clone(),
+                value: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            })
+            .clone()
+    }
+
+    /// Get or create a gauge.
+    pub fn gauge(&self, name: impl Into<String>) -> Gauge {
+        let name = name.into();
+        self.gauges
+            .entry(name.clone())
+            .or_insert_with(|| Gauge {
+                name: name.clone(),
+                value: Arc::new(std::sync::Mutex::new(0.0)),
+            })
+            .clone()
+    }
+
+    /// Get or create a histogram.
+    pub fn histogram(&self, name: impl Into<String>) -> Histogram {
+        let name = name.into();
+        self.histograms
+            .entry(name.clone())
+            .or_insert_with(|| Histogram {
+                name: name.clone(),
+                values: Arc::new(std::sync::Mutex::new(Vec::new())),
+            })
+            .clone()
+    }
+
+    /// Get all metrics as a map.
+    pub fn snapshot(&self) -> HashMap<String, Metric> {
+        let mut snapshot = HashMap::new();
+
+        for entry in self.counters.iter() {
+            snapshot.insert(
+                entry.key().clone(),
+                Metric::Counter {
+                    value: entry.value().value(),
+                },
+            );
+        }
+
+        for entry in self.gauges.iter() {
+            snapshot.insert(
+                entry.key().clone(),
+                Metric::Gauge {
+                    value: entry.value().value(),
+                },
+            );
+        }
+
+        for entry in self.histograms.iter() {
+            snapshot.insert(
+                entry.key().clone(),
+                Metric::Histogram {
+                    values: entry.value().values(),
+                },
+            );
+        }
+
+        snapshot
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_increment() {
+        let counter = Counter {
+            name: "test".into(),
+            value: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        };
+        counter.inc();
+        assert_eq!(counter.value(), 1);
+        counter.add(5);
+        assert_eq!(counter.value(), 6);
+    }
+
+    #[test]
+    fn gauge_operations() {
+        let gauge = Gauge {
+            name: "test".into(),
+            value: Arc::new(std::sync::Mutex::new(0.0)),
+        };
+        gauge.set(42.5);
+        assert_eq!(gauge.value(), 42.5);
+    }
+
+    #[test]
+    fn histogram_observe() {
+        let histogram = Histogram {
+            name: "test".into(),
+            values: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        histogram.observe(1.0);
+        histogram.observe(2.5);
+        let values = histogram.values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0], 1.0);
+        assert_eq!(values[1], 2.5);
+    }
+
+    #[test]
+    fn registry_metrics() {
+        let config = TelemetryConfig {
+            service_name: "test-service".into(),
+            environment: "test".into(),
+        };
+        let registry = MetricsRegistry::new(config);
+
+        let counter = registry.counter("requests");
+        counter.inc();
+        counter.inc();
+
+        let gauge = registry.gauge("memory");
+        gauge.set(256.0);
+
+        let histogram = registry.histogram("latency");
+        histogram.observe(50.0);
+
+        let snapshot = registry.snapshot();
+        assert_eq!(snapshot.len(), 3);
+    }
+}

--- a/crates/phenotype-telemetry/src/snapshot.rs
+++ b/crates/phenotype-telemetry/src/snapshot.rs
@@ -1,0 +1,61 @@
+//! Point-in-time metrics snapshot for reporting.
+
+use crate::registry::Metric;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Serializable snapshot of metrics at a point in time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsSnapshot {
+    pub timestamp: u64,
+    pub metrics: HashMap<String, Metric>,
+}
+
+impl MetricsSnapshot {
+    /// Create a new metrics snapshot.
+    pub fn new(metrics: HashMap<String, Metric>) -> Self {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        Self { timestamp, metrics }
+    }
+
+    /// Serialize to JSON.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_creation() {
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "test".into(),
+            Metric::Counter { value: 42 },
+        );
+
+        let snapshot = MetricsSnapshot::new(metrics);
+        assert_eq!(snapshot.metrics.len(), 1);
+        assert!(snapshot.timestamp > 0);
+    }
+
+    #[test]
+    fn snapshot_serialization() {
+        let mut metrics = HashMap::new();
+        metrics.insert(
+            "requests".into(),
+            Metric::Counter { value: 100 },
+        );
+
+        let snapshot = MetricsSnapshot::new(metrics);
+        let json = snapshot.to_json().unwrap();
+        assert!(json.contains("requests"));
+        assert!(json.contains("100"));
+    }
+}

--- a/crates/phenotype-telemetry/src/timer.rs
+++ b/crates/phenotype-telemetry/src/timer.rs
@@ -1,0 +1,109 @@
+//! Timer utilities for measuring span duration and recording in histograms.
+
+use std::time::Instant;
+
+/// RAII guard that records elapsed time to a histogram on Drop.
+pub struct SpanTimer {
+    name: String,
+    start: Instant,
+    on_drop: Option<Box<dyn Fn(String, u128) + Send>>,
+}
+
+impl std::fmt::Debug for SpanTimer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpanTimer")
+            .field("name", &self.name)
+            .field("start", &self.start)
+            .field("on_drop", &"<callback>")
+            .finish()
+    }
+}
+
+impl SpanTimer {
+    /// Create a new span timer with a name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            start: Instant::now(),
+            on_drop: None,
+        }
+    }
+
+    /// Set a callback to invoke on drop with (name, duration_ms).
+    pub fn with_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(String, u128) + Send + 'static,
+    {
+        self.on_drop = Some(Box::new(callback));
+        self
+    }
+
+    /// Get the elapsed duration in milliseconds without consuming the timer.
+    pub fn elapsed_ms(&self) -> u128 {
+        self.start.elapsed().as_millis()
+    }
+}
+
+impl Drop for SpanTimer {
+    fn drop(&mut self) {
+        if let Some(callback) = self.on_drop.take() {
+            callback(self.name.clone(), self.elapsed_ms());
+        }
+    }
+}
+
+/// Timed function wrapper — records duration and invokes callback.
+pub async fn timed<F, Fut, T>(name: &str, f: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    let start = Instant::now();
+    let result = f().await;
+    let elapsed = start.elapsed().as_millis();
+    tracing::debug!(name, elapsed_ms = elapsed, "timing recorded");
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn span_timer_elapsed() {
+        let timer = SpanTimer::new("test");
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let elapsed = timer.elapsed_ms();
+        assert!(elapsed >= 10);
+    }
+
+    #[test]
+    fn span_timer_callback() {
+        let recorded = Arc::new(AtomicU64::new(0));
+        let recorded_clone = recorded.clone();
+
+        {
+            let _timer = SpanTimer::new("test").with_callback(move |_name, duration| {
+                let duration_u64 = duration.min(u64::MAX as u128) as u64;
+                recorded_clone.store(duration_u64, Ordering::Relaxed);
+            });
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let duration = recorded.load(Ordering::Relaxed);
+        assert!(duration >= 10);
+    }
+
+    #[tokio::test]
+    async fn timed_async() {
+        let result = timed("async_op", || async {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            42
+        })
+        .await;
+
+        assert_eq!(result, 42);
+    }
+}

--- a/crates/phenotype-test-infra/src/lib.rs
+++ b/crates/phenotype-test-infra/src/lib.rs
@@ -1,4 +1,9 @@
-//! Test infrastructure for phenotype crates.
+//! Test infrastructure and utilities for phenotype crates.
+//!
+//! Provides fixtures, builders, and utilities for testing.
+
+use std::sync::Arc;
+use std::sync::Mutex;
 
 pub use phenotype_error_core::ErrorKind;
 
@@ -7,3 +12,202 @@ pub type Result<T> = std::result::Result<T, TestError>;
 
 /// Common errors that can occur in tests.
 pub type TestError = ErrorKind;
+
+// ============================================================================
+// Mock/Spy Utilities
+// ============================================================================
+
+/// A simple spy that records all calls made to it.
+#[derive(Debug, Clone)]
+pub struct CallSpy<T> {
+    calls: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T> CallSpy<T> {
+    /// Create a new spy.
+    pub fn new() -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Record a call.
+    pub fn record(&self, call: T) {
+        self.calls.lock().unwrap().push(call);
+    }
+
+    /// Get all recorded calls.
+    pub fn calls(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.calls.lock().unwrap().clone()
+    }
+
+    /// Get the number of calls.
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+
+    /// Clear all recorded calls.
+    pub fn clear(&self) {
+        self.calls.lock().unwrap().clear();
+    }
+}
+
+impl<T> Default for CallSpy<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Assertions
+// ============================================================================
+
+/// Assert that a result is ok and extract the value.
+#[macro_export]
+macro_rules! assert_ok {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => val,
+            Err(e) => panic!("Expected Ok, got Err: {:?}", e),
+        }
+    };
+}
+
+/// Assert that a result is an error.
+#[macro_export]
+macro_rules! assert_err {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => panic!("Expected Err, got Ok: {:?}", val),
+            Err(_) => (),
+        }
+    };
+}
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+/// Test data builder for reusable test scenarios.
+#[derive(Debug, Clone)]
+pub struct TestDataBuilder {
+    seed: u64,
+}
+
+impl TestDataBuilder {
+    /// Create a new test data builder.
+    pub fn new() -> Self {
+        Self { seed: 0 }
+    }
+
+    /// Create a new builder with a specific seed (for reproducibility).
+    pub fn with_seed(seed: u64) -> Self {
+        Self { seed }
+    }
+
+    /// Generate a deterministic random string.
+    pub fn random_string(&mut self) -> String {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        format!("test_{:x}", self.seed)
+    }
+
+    /// Generate a deterministic random u32.
+    pub fn random_u32(&mut self) -> u32 {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.seed >> 32) as u32
+    }
+
+    /// Generate a deterministic random bool.
+    pub fn random_bool(&mut self) -> bool {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        self.seed & 1 == 0
+    }
+}
+
+impl Default for TestDataBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn call_spy_records_calls() {
+        let spy = CallSpy::new();
+        spy.record("call1");
+        spy.record("call2");
+
+        assert_eq!(spy.call_count(), 2);
+    }
+
+    #[test]
+    fn call_spy_retrieves_calls() {
+        let spy = CallSpy::new();
+        spy.record(42);
+        spy.record(99);
+
+        let calls = spy.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0], 42);
+        assert_eq!(calls[1], 99);
+    }
+
+    #[test]
+    fn call_spy_can_be_cleared() {
+        let spy = CallSpy::new();
+        spy.record("call");
+        assert_eq!(spy.call_count(), 1);
+
+        spy.clear();
+        assert_eq!(spy.call_count(), 0);
+    }
+
+    #[test]
+    fn test_data_builder_random_strings() {
+        let mut builder = TestDataBuilder::new();
+        let s1 = builder.random_string();
+        let s2 = builder.random_string();
+
+        assert_ne!(s1, s2);
+        assert!(s1.starts_with("test_"));
+    }
+
+    #[test]
+    fn test_data_builder_reproducible() {
+        let mut b1 = TestDataBuilder::with_seed(12345);
+        let mut b2 = TestDataBuilder::with_seed(12345);
+
+        assert_eq!(b1.random_u32(), b2.random_u32());
+        assert_eq!(b1.random_bool(), b2.random_bool());
+    }
+
+    #[test]
+    fn test_data_builder_random_u32() {
+        let mut builder = TestDataBuilder::new();
+        let n1 = builder.random_u32();
+        let n2 = builder.random_u32();
+
+        assert_ne!(n1, n2);
+    }
+
+    #[test]
+    fn test_data_builder_random_bool() {
+        let mut builder = TestDataBuilder::new();
+        let values: Vec<bool> = (0..10).map(|_| builder.random_bool()).collect();
+
+        // With 10 iterations, we should have some variation (not all same)
+        let has_true = values.iter().any(|v| *v);
+        let has_false = values.iter().any(|v| !*v);
+        assert!(has_true || has_false); // At least one should be true
+    }
+}


### PR DESCRIPTION
## Summary\nThis PR adds comprehensive testing utilities and in-memory adapter implementations to the  crate. It also expands the  with necessary aggregates and events, and provides a robust  implementation in .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new workspace crates and significantly changes the public API of `phenotype-http-client-core` (transport/auth/error/retry), which can break downstream consumers despite being mostly additive elsewhere.
> 
> **Overview**
> **Adds several new reusable building blocks across the workspace.** `phenotype-contracts` now ships in-memory implementations for core outbound ports (repository/cache/event bus/secret manager) and re-exports them for test/prototype use.
> 
> **Expands AgilePlus shared types and domain modeling.** `agileplus-api-types` grows into a fuller set of request/response DTOs (pagination, project/work item/sprint, error envelope), while `agileplus-domain` adds `ProjectAggregate` plus a serializable `DomainEvent` set and exports them.
> 
> **Introduces/modernizes foundational crates.** A new `phenotype-http-client-core` crate is added to the workspace with a simplified, HTTP-crate-agnostic `HttpTransport` API plus streamlined auth and retry/error types, and `phenotype-mcp` is refactored from a `fastmcp` server implementation into pure MCP type/tool registry definitions. `phenotype-telemetry` and `phenotype-test-infra` also gain concrete metrics/timing utilities and richer test helpers (spies/macros/builders).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c573bd0790423513a88630ac41a041fecc021c9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->