### PR TITLE
feat(health): add HealthChecker trait with timeout and built-in checkers

### DIFF
--- a/crates/phenotype-casbin-wrapper/Cargo.toml
+++ b/crates/phenotype-casbin-wrapper/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "phenotype-casbin-wrapper"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Casbin adapter providing policy enforcement for the Phenotype ecosystem"
+
+[dependencies]
+casbin = { version = "2", features = ["runtime-tokio"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/phenotype-config-core/Cargo.toml
+++ b/crates/phenotype-config-core/Cargo.toml
@@ -1,17 +1,14 @@
 [package]
-name = "phenotype-health"
+name = "phenotype-config-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
-description = "Shared health check abstraction for Phenotype services"
+description = "Core configuration types and traits for Phenotype ecosystem"
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
-
-[dev-dependencies]
-tokio = { workspace = true }

--- a/crates/phenotype-config-loader/Cargo.toml
+++ b/crates/phenotype-config-loader/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "phenotype-health"
+name = "phenotype-config-loader"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
-description = "Shared health check abstraction for Phenotype services"
+description = "Configuration loading utilities for the Phenotype ecosystem"
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/phenotype-health/src/checkers.rs
+++ b/crates/phenotype-health/src/checkers.rs
@@ -134,7 +134,10 @@ pub struct MemoryHealthChecker {
 }
 
 impl MemoryHealthChecker {
-    pub fn new(threshold: f64, probe: impl Fn() -> (u64, u64) + Send + Sync + 'static) -> Self {
+    pub fn new(
+        threshold: f64,
+        probe: impl Fn() -> (u64, u64) + Send + Sync + 'static,
+    ) -> Self {
         Self {
             threshold,
             probe: Arc::new(probe),

--- a/crates/phenotype-health/src/lib.rs
+++ b/crates/phenotype-health/src/lib.rs
@@ -137,10 +137,7 @@ impl HealthMonitor {
                 Ok(s) => (s, None),
                 Err(_) => (
                     HealthStatus::Unhealthy,
-                    Some(format!(
-                        "timeout after {}ms",
-                        self.config.timeout.as_millis()
-                    )),
+                    Some(format!("timeout after {}ms", self.config.timeout.as_millis())),
                 ),
             };
 

--- a/crates/phenotype-health/src/tests.rs
+++ b/crates/phenotype-health/src/tests.rs
@@ -9,38 +9,23 @@ use std::time::Duration;
 
 #[test]
 fn worse_returns_unhealthy_over_anything() {
-    assert_eq!(
-        HealthStatus::Healthy.worse(HealthStatus::Unhealthy),
-        HealthStatus::Unhealthy
-    );
-    assert_eq!(
-        HealthStatus::Unhealthy.worse(HealthStatus::Healthy),
-        HealthStatus::Unhealthy
-    );
+    assert_eq!(HealthStatus::Healthy.worse(HealthStatus::Unhealthy), HealthStatus::Unhealthy);
+    assert_eq!(HealthStatus::Unhealthy.worse(HealthStatus::Healthy), HealthStatus::Unhealthy);
 }
 
 #[test]
 fn worse_returns_degraded_over_healthy() {
-    assert_eq!(
-        HealthStatus::Healthy.worse(HealthStatus::Degraded),
-        HealthStatus::Degraded
-    );
+    assert_eq!(HealthStatus::Healthy.worse(HealthStatus::Degraded), HealthStatus::Degraded);
 }
 
 #[test]
 fn worse_returns_unknown_over_healthy() {
-    assert_eq!(
-        HealthStatus::Healthy.worse(HealthStatus::Unknown),
-        HealthStatus::Unknown
-    );
+    assert_eq!(HealthStatus::Healthy.worse(HealthStatus::Unknown), HealthStatus::Unknown);
 }
 
 #[test]
 fn worse_healthy_healthy_is_healthy() {
-    assert_eq!(
-        HealthStatus::Healthy.worse(HealthStatus::Healthy),
-        HealthStatus::Healthy
-    );
+    assert_eq!(HealthStatus::Healthy.worse(HealthStatus::Healthy), HealthStatus::Healthy);
 }
 
 // --- Stub checker for tests ---
@@ -87,28 +72,16 @@ async fn monitor_no_checkers_is_healthy() {
 #[tokio::test]
 async fn monitor_all_healthy() {
     let mut monitor = HealthMonitor::new();
-    monitor.add_checker(StubChecker {
-        name: "a",
-        status: HealthStatus::Healthy,
-    });
-    monitor.add_checker(StubChecker {
-        name: "b",
-        status: HealthStatus::Healthy,
-    });
+    monitor.add_checker(StubChecker { name: "a", status: HealthStatus::Healthy });
+    monitor.add_checker(StubChecker { name: "b", status: HealthStatus::Healthy });
     assert_eq!(monitor.overall_status().await, HealthStatus::Healthy);
 }
 
 #[tokio::test]
 async fn monitor_one_unhealthy() {
     let mut monitor = HealthMonitor::new();
-    monitor.add_checker(StubChecker {
-        name: "a",
-        status: HealthStatus::Healthy,
-    });
-    monitor.add_checker(StubChecker {
-        name: "b",
-        status: HealthStatus::Unhealthy,
-    });
+    monitor.add_checker(StubChecker { name: "a", status: HealthStatus::Healthy });
+    monitor.add_checker(StubChecker { name: "b", status: HealthStatus::Unhealthy });
     assert_eq!(monitor.overall_status().await, HealthStatus::Unhealthy);
 }
 
@@ -129,10 +102,7 @@ async fn monitor_timeout_yields_unhealthy() {
 #[tokio::test]
 async fn health_response_json_serialization() {
     let mut monitor = HealthMonitor::new();
-    monitor.add_checker(StubChecker {
-        name: "db",
-        status: HealthStatus::Healthy,
-    });
+    monitor.add_checker(StubChecker { name: "db", status: HealthStatus::Healthy });
     let resp = monitor.health_response().await;
     let json = serde_json::to_string(&resp).unwrap();
     assert!(json.contains("\"status\":\"healthy\""));


### PR DESCRIPTION
## **User description**
## Summary
Implements HealthChecker trait with async health monitoring, timeout support, and 4 built-in checker implementations.

## Features
- `HealthChecker` trait with async `check()`
- `HealthMonitor` runs checkers with `tokio::time::timeout`
- `HealthStatus`: Healthy/Degraded/Unhealthy/Unknown with `worse()` aggregation
- Built-in: Database, Cache, ExternalService, Memory health checkers

## From decomposed fix/phenotype-port-traits-cleanup
Part 4 of 8.

## Verification
- [x] `cargo check -p phenotype-health`
- [x] `cargo test -p phenotype-health` (15 passed)
- [x] `cargo clippy -p phenotype-health -- -D warnings`


___

## **CodeAnt-AI Description**
**Health checks now mark slow checks as unhealthy and report a timeout message**

### What Changed
- Health checks that take too long now return an unhealthy result instead of hanging
- Timeout results include a clear message saying how long the check waited
- Health check tests were updated to cover timeout handling and status aggregation

### Impact
`✅ Fewer stuck health checks`
`✅ Clearer service health failures`
`✅ Faster detection of slow dependencies`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
