### PR TITLE
feat(test-infra): add CallSpy, assertion macros, and TestDataBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,16 @@ tests/test_runtime_helpers.py
 EXTRACT_PHENOTYPE_GIT_CORE_REPORT.md
 PHENOTYPE_ERROR_CORE_EXTRACTION_REPORT.md
 .github/workflows/ci.yml
+
+# Nested project directories (not tracked in this repo)
+bifrost/
+cloud/
+koosha-portfolio/
+phenotype-hub/
+phenotype-infrakit/
+AgilePlus/crates/agileplus-api-types/
+AgilePlus/crates/agileplus-error-core/
+crates/agileplus-domain/src/aggregates.rs
+crates/agileplus-domain/src/entities.rs
+crates/agileplus-domain/src/events.rs
+crates/agileplus-domain/src/values.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,13 +731,9 @@ dependencies = [
 
 [[package]]
 name = "phenotype-casbin-wrapper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "async-trait",
  "casbin",
- "dashmap",
- "phenotype-cache-adapter",
- "phenotype-telemetry",
  "serde",
  "serde_json",
  "tempfile",
@@ -903,13 +899,21 @@ name = "phenotype-telemetry"
 version = "0.2.0"
 dependencies = [
  "chrono",
- "dashmap",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "phenotype-test-infra"
+version = "0.2.0"
+dependencies = [
+ "phenotype-error-core",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/phenotype-state-machine",
     "crates/phenotype-string",
     "crates/phenotype-telemetry",
+    "crates/phenotype-test-infra",
     "crates/phenotype-validation",
 ]
 [workspace.dependencies]

--- a/crates/phenotype-test-infra/Cargo.toml
+++ b/crates/phenotype-test-infra/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "phenotype-test-infra"
-version = "0.2.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-thiserror = "2"
+serde.workspace = true
+thiserror.workspace = true
+phenotype-error-core.workspace = true

--- a/crates/phenotype-test-infra/src/lib.rs
+++ b/crates/phenotype-test-infra/src/lib.rs
@@ -1,1 +1,213 @@
-// phenotype-test-infra
+//! Test infrastructure and utilities for phenotype crates.
+//!
+//! Provides fixtures, builders, and utilities for testing.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub use phenotype_error_core::ErrorKind;
+
+/// Result type for test operations.
+pub type Result<T> = std::result::Result<T, TestError>;
+
+/// Common errors that can occur in tests.
+pub type TestError = ErrorKind;
+
+// ============================================================================
+// Mock/Spy Utilities
+// ============================================================================
+
+/// A simple spy that records all calls made to it.
+#[derive(Debug, Clone)]
+pub struct CallSpy<T> {
+    calls: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T> CallSpy<T> {
+    /// Create a new spy.
+    pub fn new() -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Record a call.
+    pub fn record(&self, call: T) {
+        self.calls.lock().unwrap().push(call);
+    }
+
+    /// Get all recorded calls.
+    pub fn calls(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.calls.lock().unwrap().clone()
+    }
+
+    /// Get the number of calls.
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+
+    /// Clear all recorded calls.
+    pub fn clear(&self) {
+        self.calls.lock().unwrap().clear();
+    }
+}
+
+impl<T> Default for CallSpy<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Assertions
+// ============================================================================
+
+/// Assert that a result is ok and extract the value.
+#[macro_export]
+macro_rules! assert_ok {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => val,
+            Err(e) => panic!("Expected Ok, got Err: {:?}", e),
+        }
+    };
+}
+
+/// Assert that a result is an error.
+#[macro_export]
+macro_rules! assert_err {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => panic!("Expected Err, got Ok: {:?}", val),
+            Err(_) => (),
+        }
+    };
+}
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+/// Test data builder for reusable test scenarios.
+#[derive(Debug, Clone)]
+pub struct TestDataBuilder {
+    seed: u64,
+}
+
+impl TestDataBuilder {
+    /// Create a new test data builder.
+    pub fn new() -> Self {
+        Self { seed: 0 }
+    }
+
+    /// Create a new builder with a specific seed (for reproducibility).
+    pub fn with_seed(seed: u64) -> Self {
+        Self { seed }
+    }
+
+    /// Generate a deterministic random string.
+    pub fn random_string(&mut self) -> String {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        format!("test_{:x}", self.seed)
+    }
+
+    /// Generate a deterministic random u32.
+    pub fn random_u32(&mut self) -> u32 {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.seed >> 32) as u32
+    }
+
+    /// Generate a deterministic random bool.
+    pub fn random_bool(&mut self) -> bool {
+        self.seed = self.seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        self.seed & 1 == 0
+    }
+}
+
+impl Default for TestDataBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn call_spy_records_calls() {
+        let spy = CallSpy::new();
+        spy.record("call1");
+        spy.record("call2");
+
+        assert_eq!(spy.call_count(), 2);
+    }
+
+    #[test]
+    fn call_spy_retrieves_calls() {
+        let spy = CallSpy::new();
+        spy.record(42);
+        spy.record(99);
+
+        let calls = spy.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0], 42);
+        assert_eq!(calls[1], 99);
+    }
+
+    #[test]
+    fn call_spy_can_be_cleared() {
+        let spy = CallSpy::new();
+        spy.record("call");
+        assert_eq!(spy.call_count(), 1);
+
+        spy.clear();
+        assert_eq!(spy.call_count(), 0);
+    }
+
+    #[test]
+    fn test_data_builder_random_strings() {
+        let mut builder = TestDataBuilder::new();
+        let s1 = builder.random_string();
+        let s2 = builder.random_string();
+
+        assert_ne!(s1, s2);
+        assert!(s1.starts_with("test_"));
+    }
+
+    #[test]
+    fn test_data_builder_reproducible() {
+        let mut b1 = TestDataBuilder::with_seed(12345);
+        let mut b2 = TestDataBuilder::with_seed(12345);
+
+        assert_eq!(b1.random_u32(), b2.random_u32());
+        assert_eq!(b1.random_bool(), b2.random_bool());
+    }
+
+    #[test]
+    fn test_data_builder_random_u32() {
+        let mut builder = TestDataBuilder::new();
+        let n1 = builder.random_u32();
+        let n2 = builder.random_u32();
+
+        assert_ne!(n1, n2);
+    }
+
+    #[test]
+    fn test_data_builder_random_bool() {
+        let mut builder = TestDataBuilder::new();
+        let values: Vec<bool> = (0..10).map(|_| builder.random_bool()).collect();
+
+        // With 10 iterations, we should have some variation (not all same)
+        let has_true = values.iter().any(|v| *v);
+        let has_false = values.iter().any(|v| !*v);
+        assert!(has_true || has_false); // At least one should be true
+    }
+}

--- a/crates/phenotype-test-infra/src/lib.rs
+++ b/crates/phenotype-test-infra/src/lib.rs
@@ -5,13 +5,13 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-pub use phenotype_error_core::ErrorKind;
+pub use phenotype_error_core::DomainError;
 
 /// Result type for test operations.
 pub type Result<T> = std::result::Result<T, TestError>;
 
 /// Common errors that can occur in tests.
-pub type TestError = ErrorKind;
+pub type TestError = DomainError;
 
 // ============================================================================
 // Mock/Spy Utilities


### PR DESCRIPTION
## **User description**
## Summary
Expands phenotype-test-infra with testing utilities.

## New Utilities
- `CallSpy` — thread-safe call recorder for verifying interactions
- `assert_ok!` / `assert_err!` — ergonomic Result assertion macros
- `TestDataBuilder` — trait for fluent test data construction

## From decomposed fix/add-http-client-core
Part 6 of 6.

## Verification
- [x] 
- [x]  (7 passed)
- [x]


___

## **CodeAnt-AI Description**
**Add shared test utilities for recording calls, checking results, and building repeatable test data**

### What Changed
- Added a shared spy that records calls, lets tests inspect them, count them, and clear them
- Added simple result-checking macros for tests that expect success or failure
- Added a reusable test data builder that creates repeatable strings, numbers, and booleans
- Added the new test support crate to the workspace and aligned it with shared workspace dependencies

### Impact
`✅ Easier interaction testing`
`✅ Shorter test setup`
`✅ Repeatable test data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
